### PR TITLE
Implement responseWriter

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -116,7 +116,10 @@ type clientProtocolHandler interface {
 	// writer. It can also return any trailers to add to the response.
 	// Some protocols may ignore the writer, some will return no
 	// trailers.
-	encodeEnd(responseEnd, io.Writer) (http.Header, error)
+	//
+	// The given codec represents the sub-format that the client used
+	// (which may be used to encode the error).
+	encodeEnd(Codec, *responseEnd, io.Writer) http.Header
 
 	// String returns a human-readable name/description of protocol.
 	String() string
@@ -152,6 +155,15 @@ type serverProtocolHandler interface {
 	String() string
 }
 
+// serverProtocolEndMustBeInHeaders is an optional interface implemented
+// by serverProtocolHandler instances to indicate if the end of an RPC
+// must be indicated in response headers (not trailers or in the body).
+// If a protocol handler does not implement this, it is assumed to be
+// false.
+type serverProtocolEndMustBeInHeaders interface {
+	endMustBeInHeaders() bool
+}
+
 // envelopedProtocolHandler is an optional interface implemented
 // by clientProtocolHandler and serverProtocolHandler instances
 // whose protocol uses an envelope around messages.
@@ -169,7 +181,11 @@ type serverEnvelopedProtocolHandler interface {
 	// set, this is called to parse the message contents. The
 	// given reader will be decompressed (even if the envelope
 	// had its compressed bit set).
-	decodeEndFromMessage(*operation, io.Reader) (responseEnd, error)
+	//
+	// The given codec represents the sub-format used to send
+	// the request to the server (which may be used to decode
+	// the error).
+	decodeEndFromMessage(Codec, io.Reader) (responseEnd, error)
 }
 
 // requestLineBuilder is an optional interface implemented by

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -49,7 +49,7 @@ func (c connectUnaryGetClientProtocol) addProtocolResponseHeaders(meta responseM
 	panic("implement me")
 }
 
-func (c connectUnaryGetClientProtocol) encodeEnd(end responseEnd, writer io.Writer) (http.Header, error) {
+func (c connectUnaryGetClientProtocol) encodeEnd(codec Codec, end *responseEnd, writer io.Writer) http.Header {
 	//TODO implement me
 	panic("implement me")
 }
@@ -103,7 +103,7 @@ func (c connectUnaryPostClientProtocol) addProtocolResponseHeaders(meta response
 	panic("implement me")
 }
 
-func (c connectUnaryPostClientProtocol) encodeEnd(end responseEnd, writer io.Writer) (http.Header, error) {
+func (c connectUnaryPostClientProtocol) encodeEnd(codec Codec, end *responseEnd, writer io.Writer) http.Header {
 	//TODO implement me
 	panic("implement me")
 }
@@ -120,9 +120,14 @@ type connectUnaryServerProtocol struct{}
 var _ serverProtocolHandler = connectUnaryServerProtocol{}
 var _ requestLineBuilder = connectUnaryServerProtocol{}
 var _ serverBodyPreparer = connectUnaryServerProtocol{}
+var _ serverProtocolEndMustBeInHeaders = connectUnaryServerProtocol{}
 
 func (c connectUnaryServerProtocol) protocol() Protocol {
 	return ProtocolConnect
+}
+
+func (c connectUnaryServerProtocol) endMustBeInHeaders() bool {
+	return true
 }
 
 func (c connectUnaryServerProtocol) addProtocolRequestHeaders(meta requestMeta, header http.Header, allowedCompression []string) {
@@ -199,7 +204,7 @@ func (c connectStreamClientProtocol) addProtocolResponseHeaders(meta responseMet
 	panic("implement me")
 }
 
-func (c connectStreamClientProtocol) encodeEnd(end responseEnd, writer io.Writer) (http.Header, error) {
+func (c connectStreamClientProtocol) encodeEnd(codec Codec, end *responseEnd, writer io.Writer) http.Header {
 	//TODO implement me
 	panic("implement me")
 }
@@ -254,7 +259,7 @@ func (c connectStreamServerProtocol) encodeEnvelope(e envelope) [5]byte {
 	panic("implement me")
 }
 
-func (c connectStreamServerProtocol) decodeEndFromMessage(o *operation, reader io.Reader) (responseEnd, error) {
+func (c connectStreamServerProtocol) decodeEndFromMessage(codec Codec, reader io.Reader) (responseEnd, error) {
 	//TODO implement me
 	panic("implement me")
 }

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -75,7 +75,7 @@ func (g grpcClientProtocol) addProtocolResponseHeaders(meta responseMeta, header
 	panic("implement me")
 }
 
-func (g grpcClientProtocol) encodeEnd(end responseEnd, writer io.Writer) (http.Header, error) {
+func (g grpcClientProtocol) encodeEnd(codec Codec, end *responseEnd, writer io.Writer) http.Header {
 	//TODO implement me
 	panic("implement me")
 }
@@ -130,7 +130,7 @@ func (g grpcServerProtocol) encodeEnvelope(e envelope) [5]byte {
 	panic("implement me")
 }
 
-func (g grpcServerProtocol) decodeEndFromMessage(o *operation, reader io.Reader) (responseEnd, error) {
+func (g grpcServerProtocol) decodeEndFromMessage(codec Codec, reader io.Reader) (responseEnd, error) {
 	//TODO implement me
 	panic("implement me")
 }
@@ -166,7 +166,7 @@ func (g grpcWebClientProtocol) addProtocolResponseHeaders(meta responseMeta, hea
 	panic("implement me")
 }
 
-func (g grpcWebClientProtocol) encodeEnd(end responseEnd, writer io.Writer) (http.Header, error) {
+func (g grpcWebClientProtocol) encodeEnd(codec Codec, end *responseEnd, writer io.Writer) http.Header {
 	//TODO implement me
 	panic("implement me")
 }
@@ -223,7 +223,7 @@ func (g grpcWebServerProtocol) encodeEnvelope(e envelope) [5]byte {
 	panic("implement me")
 }
 
-func (g grpcWebServerProtocol) decodeEndFromMessage(o *operation, reader io.Reader) (responseEnd, error) {
+func (g grpcWebServerProtocol) decodeEndFromMessage(codec Codec, reader io.Reader) (responseEnd, error) {
 	//TODO implement me
 	panic("implement me")
 }

--- a/protocol_rest.go
+++ b/protocol_rest.go
@@ -42,7 +42,7 @@ func (r restClientProtocol) addProtocolResponseHeaders(meta responseMeta, header
 	panic("implement me")
 }
 
-func (r restClientProtocol) encodeEnd(end responseEnd, writer io.Writer) (http.Header, error) {
+func (r restClientProtocol) encodeEnd(codec Codec, end *responseEnd, writer io.Writer) http.Header {
 	//TODO implement me
 	panic("implement me")
 }
@@ -78,9 +78,16 @@ type restServerProtocol struct{}
 var _ serverProtocolHandler = restServerProtocol{}
 var _ requestLineBuilder = restServerProtocol{}
 var _ serverBodyPreparer = restServerProtocol{}
+var _ serverProtocolEndMustBeInHeaders = restServerProtocol{}
 
 func (r restServerProtocol) protocol() Protocol {
 	return ProtocolREST
+}
+
+func (r restServerProtocol) endMustBeInHeaders() bool {
+	// TODO: when we support server streams over REST, this
+	//       should return false when streaming
+	return true
 }
 
 func (r restServerProtocol) addProtocolRequestHeaders(meta requestMeta, header http.Header, allowedCompression []string) {


### PR DESCRIPTION
This also tweaks some of the interfaces to handle deficiencies discovered when implementing `responseWriter`.

There still aren't tests. I next intend to flesh out some other TODOs in the `operation` type, and then add basic tests to try to cover as much logic as can be exercised without any of the protocols or body transformations implemented (mostly error cases).

Resolves TCN-2272.
