### PR TITLE
It's the client-side that matters for if the RPC end must be in headers

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -694,7 +694,7 @@ func (rw *responseWriter) WriteHeader(statusCode int) {
 
 	rw.respMeta = &respMeta
 	var endMustBeInHeaders bool
-	if mustBe, ok := rw.op.server.protocol.(serverProtocolEndMustBeInHeaders); ok {
+	if mustBe, ok := rw.op.client.protocol.(clientProtocolEndMustBeInHeaders); ok {
 		endMustBeInHeaders = mustBe.endMustBeInHeaders()
 	}
 	if !endMustBeInHeaders {

--- a/protocol.go
+++ b/protocol.go
@@ -183,12 +183,12 @@ type serverProtocolHandler interface {
 // server's codec, it also provided as the first argument.
 type responseEndUnmarshaler func(Codec, io.Reader, *responseEnd)
 
-// serverProtocolEndMustBeInHeaders is an optional interface implemented
-// by serverProtocolHandler instances to indicate if the end of an RPC
+// clientProtocolEndMustBeInHeaders is an optional interface implemented
+// by clientProtocolHandler instances to indicate if the end of an RPC
 // must be indicated in response headers (not trailers or in the body).
 // If a protocol handler does not implement this, it is assumed to be
 // false.
-type serverProtocolEndMustBeInHeaders interface {
+type clientProtocolEndMustBeInHeaders interface {
 	endMustBeInHeaders() bool
 }
 

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -29,6 +29,7 @@ type connectUnaryGetClientProtocol struct{}
 
 var _ clientProtocolHandler = connectUnaryGetClientProtocol{}
 var _ clientProtocolAllowsGet = connectUnaryGetClientProtocol{}
+var _ clientProtocolEndMustBeInHeaders = connectUnaryGetClientProtocol{}
 var _ clientBodyPreparer = connectUnaryGetClientProtocol{}
 
 func (c connectUnaryGetClientProtocol) protocol() Protocol {
@@ -42,6 +43,10 @@ func (c connectUnaryGetClientProtocol) acceptsStreamType(streamType connect.Stre
 func (c connectUnaryGetClientProtocol) allowsGetRequests(conf *methodConfig) bool {
 	methodOpts, ok := conf.descriptor.Options().(*descriptorpb.MethodOptions)
 	return ok && methodOpts.GetIdempotencyLevel() == descriptorpb.MethodOptions_NO_SIDE_EFFECTS
+}
+
+func (c connectUnaryGetClientProtocol) endMustBeInHeaders() bool {
+	return true
 }
 
 func (c connectUnaryGetClientProtocol) extractProtocolRequestHeaders(op *operation, headers http.Header) (requestMeta, error) {
@@ -96,6 +101,7 @@ func (c connectUnaryGetClientProtocol) String() string {
 type connectUnaryPostClientProtocol struct{}
 
 var _ clientProtocolHandler = connectUnaryPostClientProtocol{}
+var _ clientProtocolEndMustBeInHeaders = connectUnaryPostClientProtocol{}
 
 func (c connectUnaryPostClientProtocol) protocol() Protocol {
 	return ProtocolConnect
@@ -103,6 +109,10 @@ func (c connectUnaryPostClientProtocol) protocol() Protocol {
 
 func (c connectUnaryPostClientProtocol) acceptsStreamType(streamType connect.StreamType) bool {
 	return streamType == connect.StreamTypeUnary
+}
+
+func (c connectUnaryPostClientProtocol) endMustBeInHeaders() bool {
+	return true
 }
 
 func (c connectUnaryPostClientProtocol) extractProtocolRequestHeaders(_ *operation, headers http.Header) (requestMeta, error) {
@@ -144,14 +154,9 @@ type connectUnaryServerProtocol struct{}
 var _ serverProtocolHandler = connectUnaryServerProtocol{}
 var _ requestLineBuilder = connectUnaryServerProtocol{}
 var _ serverBodyPreparer = connectUnaryServerProtocol{}
-var _ serverProtocolEndMustBeInHeaders = connectUnaryServerProtocol{}
 
 func (c connectUnaryServerProtocol) protocol() Protocol {
 	return ProtocolConnect
-}
-
-func (c connectUnaryServerProtocol) endMustBeInHeaders() bool {
-	return true
 }
 
 func (c connectUnaryServerProtocol) addProtocolRequestHeaders(meta requestMeta, headers http.Header, allowedCompression []string) {

--- a/protocol_rest.go
+++ b/protocol_rest.go
@@ -18,6 +18,7 @@ type restClientProtocol struct{}
 
 var _ clientProtocolHandler = restClientProtocol{}
 var _ clientBodyPreparer = restClientProtocol{}
+var _ clientProtocolEndMustBeInHeaders = restClientProtocol{}
 
 // restClientProtocol implements the REST protocol for
 // processing RPCs received from the client.
@@ -28,6 +29,11 @@ func (r restClientProtocol) protocol() Protocol {
 func (r restClientProtocol) acceptsStreamType(streamType connect.StreamType) bool {
 	// TODO: support connect.StreamTypeServer, too
 	return streamType == connect.StreamTypeUnary
+}
+
+func (r restClientProtocol) endMustBeInHeaders() bool {
+	// TODO: when we support server streams over REST, this should return false when streaming
+	return true
 }
 
 func (r restClientProtocol) extractProtocolRequestHeaders(op *operation, headers http.Header) (requestMeta, error) {
@@ -98,16 +104,9 @@ type restServerProtocol struct{}
 var _ serverProtocolHandler = restServerProtocol{}
 var _ requestLineBuilder = restServerProtocol{}
 var _ serverBodyPreparer = restServerProtocol{}
-var _ serverProtocolEndMustBeInHeaders = restServerProtocol{}
 
 func (r restServerProtocol) protocol() Protocol {
 	return ProtocolREST
-}
-
-func (r restServerProtocol) endMustBeInHeaders() bool {
-	// TODO: when we support server streams over REST, this
-	//       should return false when streaming
-	return true
 }
 
 func (r restServerProtocol) addProtocolRequestHeaders(meta requestMeta, headers http.Header, allowedCompression []string) {


### PR DESCRIPTION
I had added this interface and logic with the purpose that we _delay_ flushing headers until we know we can actually process the response.

This is valuable for REST and Connect unary protocols, where we need to send any errors in the _headers_, and can't wait and then send them in the body or as trailers.

So if the client-side protocol requires that the RPC end (e.g. errors) be known before flushing headers, then we delay flushing them until the response body is processed. So if there's an error processing the response message, we can encode that as an error reply (and still have a chance to set the HTTP status code, etc).

The part of this flow that is not yet written is that the `envelopingWriter` and `transformingWriter` will both need to call `responseWriter.flushHeaders` before they actually write something. So if an error happens while transforming a message, then can instead call `responseWriter.reportError`.