### PR TITLE
Use first registered codec instead of always falling back to CodecProto

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -137,8 +137,7 @@ func (h *handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 	} else if _, supportsCodec := methodConf.codecNames[reqMeta.codec]; supportsCodec {
 		op.server.codec = op.client.codec
 	} else {
-		// TODO: use preferred codec from service registration instead of always using proto?
-		op.server.codec = h.codecs[codecKey{res: methodConf.resolver, name: CodecProto}]
+		op.server.codec = h.codecs[codecKey{res: methodConf.resolver, name: methodConf.preferredCodec}]
 	}
 
 	if reqMeta.compression != "" && !cannotDecompressRequest {

--- a/vanguard_rpcxrpc_test.go
+++ b/vanguard_rpcxrpc_test.go
@@ -207,12 +207,21 @@ func TestMux_RPCxRPC(t *testing.T) {
 		"GetBook_gRPC-Web_proto_identity/gRPC-Web_proto_identity": {},
 		// transformation is working
 		"GetBook_gRPC_json_gzip/gRPC_proto_gzip":                 {},
+		"GetBook_gRPC_proto_gzip/gRPC_json_gzip":                 {},
 		"GetBook_gRPC-Web_json_gzip/gRPC_proto_gzip":             {},
+		"GetBook_gRPC-Web_proto_gzip/gRPC_json_gzip":             {},
 		"GetBook_gRPC_json_identity/gRPC_proto_identity":         {},
+		"GetBook_gRPC_proto_identity/gRPC_json_identity":         {},
 		"GetBook_gRPC-Web_json_identity/gRPC_proto_identity":     {},
+		"GetBook_gRPC-Web_proto_identity/gRPC_json_identity":     {},
 		"GetBook_gRPC_json_gzip/gRPC-Web_proto_gzip":             {},
+		"GetBook_gRPC_proto_gzip/gRPC-Web_json_gzip":             {},
 		"GetBook_gRPC_json_identity/gRPC-Web_proto_identity":     {},
+		"GetBook_gRPC_proto_identity/gRPC-Web_json_identity":     {},
+		"GetBook_gRPC-Web_json_gzip/gRPC-Web_proto_gzip":         {},
+		"GetBook_gRPC-Web_proto_gzip/gRPC-Web_json_gzip":         {},
 		"GetBook_gRPC-Web_json_identity/gRPC-Web_proto_identity": {},
+		"GetBook_gRPC-Web_proto_identity/gRPC-Web_json_identity": {},
 	}
 	for _, testCase := range testRequests {
 		testCase := testCase


### PR DESCRIPTION
This was why some of the RPC-to-RPC tests were failing: the logic was just falling back to proto, though test expectations were asserting that the requests should be coming in as JSON.

So this is a simple fix that gets more of the tests passing.