### PR TITLE
Implement Connect streaming protocol

### DIFF
--- a/protocol_http.go
+++ b/protocol_http.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/textproto"
 	"net/url"
 	"strconv"
 	"strings"
@@ -252,7 +253,7 @@ func httpExtractTrailers(headers http.Header) http.Header {
 	expectedTrailerSet := make(map[string]struct{})
 	for _, vals := range headers.Values("Trailer") {
 		for _, val := range strings.Split(vals, ",") {
-			val = strings.TrimSpace(val)
+			val = textproto.CanonicalMIMEHeaderKey(strings.TrimSpace(val))
 			expectedTrailerSet[val] = struct{}{}
 		}
 	}


### PR DESCRIPTION
To actually test the streaming protocol, this also adds numerous new test cases to the RPCxRPC tests, including client, server, and bidi streams as well as error cases.

In order to add those test cases, I first overhauled the structure of RPCxRPC to match the basic form of `TestHandler_PassThrough`, which reduces the boiler-plate in setting up test streams quite a lot.

Resolves TCN-2283 and TCN-2290.
