### PR TITLE
Remove unused "Te" and "Trailer" headers when translating from gRPC

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -880,9 +880,9 @@ func (rw *responseWriter) WriteHeader(statusCode int) {
 	// snapshot trailer keys
 	trailerKeys := parseMultiHeader(rw.Header().Values("Trailer"))
 	if len(trailerKeys) > 0 {
-		respMeta.pendingTrailerKeys = make(map[string]struct{}, len(trailerKeys))
+		respMeta.pendingTrailerKeys = make(headerKeys, len(trailerKeys))
 		for _, k := range trailerKeys {
-			respMeta.pendingTrailerKeys[strings.ToLower(k)] = struct{}{}
+			respMeta.pendingTrailerKeys.add(k)
 		}
 		rw.Header().Del("Trailer")
 	}

--- a/protocol.go
+++ b/protocol.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/textproto"
 	"strings"
 	"time"
 
@@ -350,7 +351,7 @@ type responseMeta struct {
 	compression        string
 	acceptCompression  []string
 	pendingTrailers    http.Header
-	pendingTrailerKeys map[string]struct{}
+	pendingTrailerKeys headerKeys
 }
 
 // responseEnd is a protocol-agnostic representation of the disposition
@@ -371,6 +372,17 @@ type responseEnd struct {
 	// This can be used by a protocol handler that also encodes the end
 	// in a stream payload to decide whether to compress the final frame.
 	wasCompressed bool
+}
+
+type headerKeys map[string]struct{}
+
+func (keys headerKeys) add(k string) {
+	keys[textproto.CanonicalMIMEHeaderKey(k)] = struct{}{}
+}
+
+func (keys headerKeys) contains(k string) bool {
+	_, contains := keys[textproto.CanonicalMIMEHeaderKey(k)]
+	return contains
 }
 
 // parseMultiHeader parses headers that allow multiple values. It

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -86,19 +86,19 @@ func (g grpcClientProtocol) addProtocolResponseHeaders(meta responseMeta, header
 	statusCode := grpcAddResponseMeta("application/grpc+", meta, headers)
 	if len(meta.pendingTrailers) > 0 {
 		if meta.pendingTrailerKeys == nil {
-			meta.pendingTrailerKeys = make(map[string]struct{}, len(meta.pendingTrailers))
+			meta.pendingTrailerKeys = make(headerKeys, len(meta.pendingTrailers))
 		}
 		for k := range meta.pendingTrailers {
-			meta.pendingTrailerKeys[strings.ToLower(k)] = struct{}{}
+			meta.pendingTrailerKeys.add(k)
 		}
 	}
 	for k := range meta.pendingTrailerKeys {
 		headers.Add("Trailer", textproto.CanonicalMIMEHeaderKey(k))
 	}
-	if _, hasStatus := meta.pendingTrailerKeys["grpc-status"]; !hasStatus {
+	if !meta.pendingTrailerKeys.contains("Grpc-Status") {
 		headers.Add("Trailer", "Grpc-Status")
 	}
-	if _, hasMessage := meta.pendingTrailerKeys["grpc-message"]; !hasMessage {
+	if !meta.pendingTrailerKeys.contains("Grpc-Message") {
 		headers.Add("Trailer", "Grpc-Message")
 	}
 	return statusCode

--- a/protocol_http.go
+++ b/protocol_http.go
@@ -258,7 +258,7 @@ func httpEncodePathValues(input protoreflect.Message, target *routeTarget) (
 	return path, query, nil
 }
 
-func httpExtractTrailers(headers http.Header, knownTrailerKeys map[string]struct{}) http.Header {
+func httpExtractTrailers(headers http.Header, knownTrailerKeys headerKeys) http.Header {
 	trailers := make(http.Header, len(knownTrailerKeys))
 	for key, vals := range headers {
 		if strings.HasPrefix(key, http.TrailerPrefix) {
@@ -266,7 +266,7 @@ func httpExtractTrailers(headers http.Header, knownTrailerKeys map[string]struct
 			delete(headers, key)
 			continue
 		}
-		if _, expected := knownTrailerKeys[strings.ToLower(key)]; expected {
+		if _, expected := knownTrailerKeys[key]; expected {
 			trailers[key] = vals
 			delete(headers, key)
 			continue


### PR DESCRIPTION
There were some TODOs about this, and I _really_ noticed when looking at the trace output of requests for the demo servers in [jh/demo-example](https://github.com/bufbuild/vanguard-go/compare/jh/demo-example).

So this cleans up the use of these headers. Basically, the gRPC protocol, the only one expecting the "te: trailers" header, will strip it when extracting other protocol headers.

For "trailers", for the gRPC protocol, we'd like to be able to set "trailer" headers for all known trailers up-front. So we can't just strip the "trailer" header, because then we won't know later which trailer keys to expect. So we now _snapshot_ the trailer keys and save them in `responseMeta`, so that we can then use them specifically in the gRPC protocol, so it can add "trailer" headers for all expected trailer keys.