### PR TITLE
Use of gRPC requires http/2; use connect's JSON codec

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -36,7 +36,7 @@ type handler struct {
 	canDecompress []string
 }
 
-func (h *handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+func (h *handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) { //nolint:gocyclo
 	// Identify the protocol.
 	clientProtoHandler, originalContentType, queryVars := classifyRequest(request)
 	if clientProtoHandler == nil {
@@ -83,6 +83,10 @@ func (h *handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 	}
 	if op.methodConf.streamType == connect.StreamTypeBidi && request.ProtoMajor < 2 {
 		http.Error(writer, "bidi streams require HTTP/2", http.StatusHTTPVersionNotSupported)
+		return
+	}
+	if clientProtoHandler.protocol() == ProtocolGRPC && request.ProtoMajor != 2 {
+		http.Error(writer, "gRPC requires HTTP/2", http.StatusHTTPVersionNotSupported)
 		return
 	}
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/genproto/googleapis/api/httpbody"
-	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -516,10 +515,7 @@ func TestHandler_PassThrough(t *testing.T) {
 		},
 		{
 			name: "json",
-			// NB: connect has a JSON codec implementation, but it is not exposed or
-			//     selectable from the client; it is only available for handlers when
-			//     handling requests that use this format ¯\_(ツ)_/¯
-			opts: []connect.ClientOption{connect.WithCodec(jsonConnectCodec{})},
+			opts: []connect.ClientOption{connect.WithProtoJSON()},
 		},
 	}
 	protocolOptions := []connectClientCase{
@@ -1224,26 +1220,4 @@ func rot13(data []byte) {
 		}
 		data[index] = char
 	}
-}
-
-type jsonConnectCodec struct{}
-
-func (j jsonConnectCodec) Name() string {
-	return CodecJSON
-}
-
-func (j jsonConnectCodec) Marshal(a any) ([]byte, error) {
-	msg, ok := a.(proto.Message)
-	if !ok {
-		return nil, errors.New("not a message")
-	}
-	return protojson.Marshal(msg)
-}
-
-func (j jsonConnectCodec) Unmarshal(bytes []byte, a any) error {
-	msg, ok := a.(proto.Message)
-	if !ok {
-		return errors.New("not a message")
-	}
-	return protojson.Unmarshal(bytes, msg)
 }

--- a/vanguard_rpcxrest_test.go
+++ b/vanguard_rpcxrest_test.go
@@ -90,7 +90,9 @@ func TestMux_RPCxREST(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
-		server := httptest.NewServer(mux.AsHandler())
+		server := httptest.NewUnstartedServer(mux.AsHandler())
+		server.EnableHTTP2 = true
+		server.StartTLS()
 		disableCompression(server)
 		t.Cleanup(server.Close)
 		return testServer{name: name, svr: server}


### PR DESCRIPTION
We previously allowed gRPC as the incoming protocol, as long as the method didn't use bidirectional streams. But that's not technically correct.

Also, I had failed to find the `WithProtoJSON()` function in the Connect repo when trying to configure a client to use JSON. Doh! 🤦 

This fixes both issues.