### PR TITLE
Drop support for subfield bodies in methods

### DIFF
--- a/router.go
+++ b/router.go
@@ -235,9 +235,21 @@ func makeTarget(
 	if err != nil {
 		return nil, err
 	}
+	if len(requestBodyFields) > 1 {
+		return nil, fmt.Errorf(
+			"unexpected request body path %q: must be a single field",
+			requestBody,
+		)
+	}
 	responseBodyFields, err := resolvePathToDescriptors(config.descriptor.Output(), responseBody)
 	if err != nil {
 		return nil, err
+	}
+	if len(responseBodyFields) > 1 {
+		return nil, fmt.Errorf(
+			"unexpected response body path %q: must be a single field",
+			requestBody,
+		)
 	}
 	routeTargetVars := make([]routeTargetVar, len(variables))
 	for i, variable := range variables {


### PR DESCRIPTION
Not sure it hurts to keep but following the spec [must be top level field](https://github.com/googleapis/googleapis/blob/1e1f87aa23488297fe83491491aa86e74201ec40/google/api/http.proto#L354-L355)

Keep it as an array as the selection logic works on multiple fields for URL paths variables and query params.