### PR TITLE
Add fallback for parsing invalid rest errors

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -15,6 +15,7 @@
 package vanguard
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net/http"
@@ -219,9 +220,9 @@ type serverProtocolHandler interface {
 }
 
 // responseEndUnmarshaller populates the given responseEnd by unmarshalling
-// information from the given reader. If unmarshalling needs to know the
+// information from the given buffer. If unmarshalling needs to know the
 // server's codec, it also provided as the first argument.
-type responseEndUnmarshaller func(Codec, io.Reader, *responseEnd)
+type responseEndUnmarshaller func(Codec, *bytes.Buffer, *responseEnd)
 
 // clientProtocolEndMustBeInHeaders is an optional interface implemented
 // by clientProtocolHandler instances to indicate if the end of an RPC

--- a/protocol_http_test.go
+++ b/protocol_http_test.go
@@ -50,7 +50,7 @@ func TestHTTPErrorWriter(t *testing.T) {
 	assert.NoError(t, json.Compact(&out, rec.Body.Bytes()))
 	assert.Equal(t, `{"code":16,"message":"test error: Hello, 世界","details":[]}`, out.String())
 
-	body := bytes.NewReader(rec.Body.Bytes())
+	body := bytes.NewBuffer(rec.Body.Bytes())
 	got := httpErrorFromResponse(http.StatusUnauthorized, "application/json", body)
 	assert.Equal(t, cerr, got)
 }
@@ -78,13 +78,13 @@ func TestHTTPErrorFromResponse(t *testing.T) {
 		}
 		out, err := protojson.Marshal(&stat)
 		require.Nil(t, err)
-		got := httpErrorFromResponse(http.StatusUnauthorized, "application/json", bytes.NewReader(out))
+		got := httpErrorFromResponse(http.StatusUnauthorized, "application/json", bytes.NewBuffer(out))
 		assert.Equal(t, connect.CodeUnauthenticated, got.Code())
 		assert.Equal(t, "auth error", got.Message())
 	})
 	t.Run("invalidStatus", func(t *testing.T) {
 		t.Parallel()
-		body := bytes.NewReader([]byte("unauthorized"))
+		body := bytes.NewBufferString("unauthorized")
 		got := httpErrorFromResponse(http.StatusUnauthorized, "application/json", body)
 		assert.Equal(t, connect.CodeUnauthenticated, got.Code())
 		assert.Equal(t, "Unauthorized", got.Message())
@@ -105,7 +105,7 @@ func TestHTTPErrorFromResponse(t *testing.T) {
 		out, err := protojson.Marshal(&stat)
 		require.Nil(t, err)
 		out = append(out[:len(out)-1], []byte(`,"details":{"@type":"foo","value":"bar"}`)...)
-		got := httpErrorFromResponse(http.StatusUnauthorized, "application/json", bytes.NewReader(out))
+		got := httpErrorFromResponse(http.StatusUnauthorized, "application/json", bytes.NewBuffer(out))
 		t.Log(got)
 		assert.Equal(t, connect.CodeUnauthenticated, got.Code())
 		assert.Equal(t, "Unauthorized", got.Message())

--- a/protocol_rest.go
+++ b/protocol_rest.go
@@ -16,6 +16,7 @@
 package vanguard
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net/http"
@@ -284,8 +285,8 @@ func (r restServerProtocol) extractProtocolResponseHeaders(statusCode int, heade
 	if statusCode/100 != 2 {
 		return responseMeta{
 				end: &responseEnd{httpCode: statusCode},
-			}, func(_ Codec, src io.Reader, end *responseEnd) {
-				if err := httpErrorFromResponse(statusCode, contentType, src); err != nil {
+			}, func(_ Codec, buf *bytes.Buffer, end *responseEnd) {
+				if err := httpErrorFromResponse(statusCode, contentType, buf); err != nil {
 					end.err = err
 					end.httpCode = httpStatusCodeFromRPC(err.Code())
 				}


### PR DESCRIPTION
Used https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md for rpc status mapping.

Fixes TCN-2345