### PR TITLE
Use options for binding services

### DIFF
--- a/internal/examples/connect+grpc/cmd/server/main.go
+++ b/internal/examples/connect+grpc/cmd/server/main.go
@@ -28,6 +28,7 @@ import (
 
 	"buf.build/gen/go/connectrpc/eliza/grpc/go/connectrpc/eliza/v1/elizav1grpc"
 	elizav1 "buf.build/gen/go/connectrpc/eliza/protocolbuffers/go/connectrpc/eliza/v1"
+	"connectrpc.com/vanguard"
 	"connectrpc.com/vanguard/vanguardgrpc"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
@@ -42,7 +43,9 @@ func main() {
 	// Now wrap it with a Vanguard transcoder to upgrade it to
 	// also supporting Connect and gRPC-Web (and even REST,
 	// if the gRPC service schemas have HTTP annotations).
-	handler, err := vanguardgrpc.NewTranscoder(server)
+	handler, err := vanguard.NewTranscoder(
+		vanguardgrpc.WithGRPCServer(server),
+	)
 	if err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/internal/examples/fileserver/main.go
+++ b/internal/examples/fileserver/main.go
@@ -46,8 +46,9 @@ func main() {
 		FS: os.DirFS(*directory),
 	}
 	// And wrap it with Vanguard.
-	service := vanguard.NewService(testv1connect.NewContentServiceHandler(serviceHandler))
-	handler, err := vanguard.NewTranscoder([]*vanguard.Service{service})
+	handler, err := vanguard.NewTranscoder(
+		vanguard.WithService(testv1connect.NewContentServiceHandler(serviceHandler)),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/examples/pets/cmd/pets-be/main.go
+++ b/internal/examples/pets/cmd/pets-be/main.go
@@ -47,8 +47,10 @@ func main() {
 	// Wrap the proxy handler with Vanguard, so it can accept Connect, gRPC, or gRPC-Web
 	// and transform the requests to REST+JSON.
 	handler, err := vanguard.NewTranscoder(
-		[]*vanguard.Service{vanguard.NewService(petstorev2connect.PetServiceName, proxy)},
-		vanguard.WithTargetProtocols(vanguard.ProtocolREST),
+		vanguard.WithService(petstorev2connect.PetServiceName, proxy),
+		vanguard.WithDefaultServiceOptions(
+			vanguard.WithTargetProtocols(vanguard.ProtocolREST),
+		),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/internal/examples/pets/cmd/pets-fe/main.go
+++ b/internal/examples/pets/cmd/pets-fe/main.go
@@ -82,7 +82,7 @@ func main() {
 		// transform it to a particular protocol (based on the port used to send the request)
 		// before sending to the pets-be server.
 		handler, err := vanguard.NewTranscoder(
-			[]*vanguard.Service{vanguard.NewService(petstorev2connect.PetServiceName, proxy, opts...)},
+			vanguard.WithService(petstorev2connect.PetServiceName, proxy, opts...),
 		)
 		if err != nil {
 			log.Fatal(err)

--- a/transcoder.go
+++ b/transcoder.go
@@ -31,11 +31,11 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// Transcoder is a Vanguard handler which acts like a router and a middleware. It transforms
-// all supported input protocols (Connect, gRPC, gRPC-Web, REST) into a protocol that the
-// service handlers support. It can do simple routing based on RPC method name, for simple
-// protocols like Connect, gRPC, and gRPC-Web; but it can also route based on REST-ful URI
-// paths configured with HTTP transcoding annotations.
+// Transcoder implements protocol conversion to and from all supported protocols,
+// encoding formats, and compression schemes. It can do simple routing based on
+// RPC method name, for simple protocols like Connect, gRPC, and gRPC-Web. It
+// also will route based on REST-ful URI paths configured with HTTP transcoding
+// annotations.
 type Transcoder struct {
 	bufferPool     bufferPool
 	codecs         codecMap

--- a/transcoder_bench_test.go
+++ b/transcoder_bench_test.go
@@ -127,7 +127,7 @@ func BenchmarkServeHTTP(b *testing.B) {
 		rspGRPCBody := envelopePayload(1, rspMsgProtoComp)
 
 		handler, err := NewTranscoder(
-			[]*Service{NewService(
+			WithService(
 				testv1connect.LibraryServiceName,
 				benchHandler(b, rspGRPCBody, http.Header{
 					"Grpc-Encoding": []string{"gzip"},
@@ -136,8 +136,10 @@ func BenchmarkServeHTTP(b *testing.B) {
 				}, http.Header{
 					"Grpc-Status": []string{"0"},
 				}),
-			)},
-			WithTargetProtocols(ProtocolGRPC),
+			),
+			WithDefaultServiceOptions(
+				WithTargetProtocols(ProtocolGRPC),
+			),
 		)
 		require.NoError(b, err)
 
@@ -170,7 +172,7 @@ func BenchmarkServeHTTP(b *testing.B) {
 		rspGRPCBody := envelopePayload(0, rspMsgProto)
 
 		handler, err := NewTranscoder(
-			[]*Service{NewService(
+			WithService(
 				testv1connect.LibraryServiceName,
 				benchHandler(b, rspGRPCBody, http.Header{
 					"Content-Type": []string{"application/grpc+proto"},
@@ -178,10 +180,12 @@ func BenchmarkServeHTTP(b *testing.B) {
 				}, http.Header{
 					"Grpc-Status": []string{"0"},
 				}),
-			)},
-			WithTargetProtocols(ProtocolGRPC),
-			WithTargetCodecs(CodecProto),
-			WithNoTargetCompression(),
+			),
+			WithDefaultServiceOptions(
+				WithTargetProtocols(ProtocolGRPC),
+				WithTargetCodecs(CodecProto),
+				WithNoTargetCompression(),
+			),
 		)
 		require.NoError(b, err)
 
@@ -217,15 +221,17 @@ func BenchmarkServeHTTP(b *testing.B) {
 		rspGRPCBody := envelopePayload(0, rspMsgProto)
 
 		handler, err := NewTranscoder(
-			[]*Service{NewService(
+			WithService(
 				testv1connect.LibraryServiceName,
 				benchHandler(b, rspMsgJSON, http.Header{
 					"Content-Type": []string{"application/json"},
 				}, nil),
-			)},
-			WithTargetProtocols(ProtocolREST),
-			WithTargetCodecs(CodecJSON),
-			WithNoTargetCompression(),
+			),
+			WithDefaultServiceOptions(
+				WithTargetProtocols(ProtocolREST),
+				WithTargetCodecs(CodecJSON),
+				WithNoTargetCompression(),
+			),
 		)
 		require.NoError(b, err)
 
@@ -258,7 +264,7 @@ func BenchmarkServeHTTP(b *testing.B) {
 		rspGRPCBody := envelopePayload(0, rspMsgProto)
 
 		handler, err := NewTranscoder(
-			[]*Service{NewService(
+			WithService(
 				testv1connect.LibraryServiceName,
 				benchHandler(b, rspGRPCBody, http.Header{
 					"Content-Type": []string{"application/grpc+proto"},
@@ -266,10 +272,12 @@ func BenchmarkServeHTTP(b *testing.B) {
 				}, http.Header{
 					"Grpc-Status": []string{"0"},
 				}),
-			)},
-			WithTargetProtocols(ProtocolGRPC),
-			WithTargetCodecs(CodecProto),
-			WithNoTargetCompression(),
+			),
+			WithDefaultServiceOptions(
+				WithTargetProtocols(ProtocolGRPC),
+				WithTargetCodecs(CodecProto),
+				WithNoTargetCompression(),
+			),
 		)
 		require.NoError(b, err)
 
@@ -303,7 +311,7 @@ func BenchmarkServeHTTP(b *testing.B) {
 		rspGRPCBody := envelopePayload(1, rspMsgProtoComp)
 
 		handler, err := NewTranscoder(
-			[]*Service{NewService(
+			WithService(
 				testv1connect.LibraryServiceName,
 				benchHandler(b, rspGRPCBody, http.Header{
 					"Content-Type":  []string{"application/grpc+proto"},
@@ -312,9 +320,11 @@ func BenchmarkServeHTTP(b *testing.B) {
 				}, http.Header{
 					"Grpc-Status": []string{"0"},
 				}),
-			)},
-			WithTargetProtocols(ProtocolGRPC),
-			WithTargetCodecs(CodecProto),
+			),
+			WithDefaultServiceOptions(
+				WithTargetProtocols(ProtocolGRPC),
+				WithTargetCodecs(CodecProto),
+			),
 		)
 		require.NoError(b, err)
 
@@ -351,7 +361,7 @@ func BenchmarkServeHTTP(b *testing.B) {
 		rspGRPC := envelopePayload(0, marshalProto(&emptypb.Empty{}))
 
 		handler, err := NewTranscoder(
-			[]*Service{NewService(
+			WithService(
 				testv1connect.ContentServiceName,
 				benchHandler(b, rspGRPC, http.Header{
 					"Content-Type":  []string{"application/grpc+proto"},
@@ -360,9 +370,11 @@ func BenchmarkServeHTTP(b *testing.B) {
 				}, http.Header{
 					"Grpc-Status": []string{"0"},
 				}),
-			)},
-			WithTargetProtocols(ProtocolGRPC),
-			WithTargetCodecs(CodecProto),
+			),
+			WithDefaultServiceOptions(
+				WithTargetProtocols(ProtocolGRPC),
+				WithTargetCodecs(CodecProto),
+			),
 		)
 		require.NoError(b, err)
 

--- a/vanguard_examples_test.go
+++ b/vanguard_examples_test.go
@@ -44,9 +44,9 @@ func ExampleNewTranscoder_restToConnect() {
 	// RPC service implementing testv1connect.LibraryService annotations.
 	svc := &libraryRPC{}
 
-	handler, err := vanguard.NewTranscoder([]*vanguard.Service{
-		vanguard.NewService(testv1connect.NewLibraryServiceHandler(svc)),
-	})
+	handler, err := vanguard.NewTranscoder(
+		vanguard.WithService(testv1connect.NewLibraryServiceHandler(svc)),
+	)
 	if err != nil {
 		log.Println("error:", err)
 		return
@@ -103,9 +103,11 @@ func ExampleNewTranscoder_connectToREST() {
 	svc := &libraryREST{}
 
 	handler, err := vanguard.NewTranscoder(
-		[]*vanguard.Service{vanguard.NewService(testv1connect.LibraryServiceName, svc)},
+		vanguard.WithService(testv1connect.LibraryServiceName, svc),
 		// This tells vanguard that it must transform requests to REST.
-		vanguard.WithTargetProtocols(vanguard.ProtocolREST),
+		vanguard.WithDefaultServiceOptions(
+			vanguard.WithTargetProtocols(vanguard.ProtocolREST),
+		),
 	)
 	if err != nil {
 		log.Println("error:", err)

--- a/vanguard_restxrpc_test.go
+++ b/vanguard_restxrpc_test.go
@@ -76,23 +76,23 @@ func TestMux_RESTxRPC(t *testing.T) {
 		handler http.Handler
 	}
 	makeMux := func(protocol Protocol, codec, compression string) testMux {
-		opts := []ServiceOption{
+		svcOpts := []ServiceOption{
 			WithTargetProtocols(protocol),
 			WithTargetCodecs(codec),
 		}
 		if compression != CompressionIdentity {
-			opts = append(opts, WithTargetCompression(compression))
+			svcOpts = append(svcOpts, WithTargetCompression(compression))
 		} else {
-			opts = append(opts, WithNoTargetCompression())
+			svcOpts = append(svcOpts, WithNoTargetCompression())
 		}
 		svcHandler := protocolAssertMiddleware(protocol, codec, compression, serveMux)
 		name := fmt.Sprintf("%s_%s_%s", protocol, codec, compression)
 
-		services := make([]*Service, len(serviceNames))
+		opts := make([]TranscoderOption, len(serviceNames))
 		for i, svcName := range serviceNames {
-			services[i] = NewService(svcName, svcHandler, opts...)
+			opts[i] = WithService(svcName, svcHandler, svcOpts...)
 		}
-		handler, err := NewTranscoder(services)
+		handler, err := NewTranscoder(opts...)
 		require.NoError(t, err)
 		return testMux{name: name, handler: handler}
 	}

--- a/vanguard_rpcxrpc_test.go
+++ b/vanguard_rpcxrpc_test.go
@@ -64,23 +64,23 @@ func TestMux_RPCxRPC(t *testing.T) {
 	))
 
 	makeServer := func(protocol Protocol, codec, compression string) testServer {
-		opts := []ServiceOption{
+		svcOpts := []ServiceOption{
 			WithTargetProtocols(protocol),
 			WithTargetCodecs(codec),
 		}
 		if compression == CompressionIdentity {
-			opts = append(opts, WithNoTargetCompression())
+			svcOpts = append(svcOpts, WithNoTargetCompression())
 		} else {
-			opts = append(opts, WithTargetCompression(compression))
+			svcOpts = append(svcOpts, WithTargetCompression(compression))
 		}
 		svcHandler := protocolAssertMiddleware(protocol, codec, compression, serveMux)
 		name := fmt.Sprintf("%s_%s_%s", protocol, codec, compression)
 
-		services := make([]*Service, len(serviceNames))
+		opts := make([]TranscoderOption, len(serviceNames))
 		for i, svcName := range serviceNames {
-			services[i] = NewService(svcName, svcHandler, opts...)
+			opts[i] = WithService(svcName, svcHandler, svcOpts...)
 		}
-		handler, err := NewTranscoder(services)
+		handler, err := NewTranscoder(opts...)
 		require.NoError(t, err)
 		server := httptest.NewUnstartedServer(handler)
 		server.EnableHTTP2 = true

--- a/vanguardgrpc/vanguardgrpc_examples_test.go
+++ b/vanguardgrpc/vanguardgrpc_examples_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"connectrpc.com/vanguard"
 	testv1 "connectrpc.com/vanguard/internal/gen/vanguard/test/v1"
 	"connectrpc.com/vanguard/internal/gen/vanguard/test/v1/testv1connect"
 	"connectrpc.com/vanguard/vanguardgrpc"
@@ -47,7 +48,9 @@ func ExampleNewTranscoder_connectToGRPC() {
 	testv1.RegisterLibraryServiceServer(grpcServer, svc)
 
 	// Create a vanguard handler for all services registered in grpcServer
-	handler, err := vanguardgrpc.NewTranscoder(grpcServer)
+	handler, err := vanguard.NewTranscoder(
+		vanguardgrpc.WithGRPCServer(grpcServer),
+	)
 	if err != nil {
 		log.Println("error:", err)
 		return


### PR DESCRIPTION
Idea for keeping service bindings as Options. `ServiceOption` no longer implements `TranscoderOption`. To add default service options call: `WithDefaultServiceOption(svcOpts...)`. This lets us hide the `*Service` implementation and move `NewService` and `NewServiceWithSchema` to `WithService` and `WithServiceFromSchema`. 

`vanguardgrpc` no longer returns a `http.Handler` but instead creates a new option for the transcoder:
```go
handler, err := vanguard.NewTranscoder(
    vanguardgrpc.WithGRPCServer(server),
)
```