### PR TITLE
Add tests for proxy configuration

### DIFF
--- a/transcoder.go
+++ b/transcoder.go
@@ -471,18 +471,6 @@ func (o *operation) queryValues() url.Values {
 }
 
 func (o *operation) handle() {
-	// Deferred function to capture http.ErrAbortHandler panics.
-	defer func() {
-		if recovered := recover(); recovered != nil {
-			if err, ok := recovered.(error); ok {
-				if errors.Is(err, http.ErrAbortHandler) {
-					return
-				}
-			}
-			panic(recovered) //nolint:forbidigo // re-throw the panic if unknown
-		}
-	}()
-
 	o.clientEnveloper, _ = o.client.protocol.(envelopedProtocolHandler)
 	o.clientPreparer, _ = o.client.protocol.(clientBodyPreparer)
 	if o.clientPreparer != nil {

--- a/vanguard_restxrpc_test.go
+++ b/vanguard_restxrpc_test.go
@@ -16,6 +16,7 @@ package vanguard
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -110,7 +111,7 @@ func TestMux_RESTxRPC(t *testing.T) {
 					handler: wrapHandler(protocol, codec, compression, serveMux),
 				})
 				muxes = append(muxes, testMux{
-					name:    fmt.Sprintf("proxy_%s_%s_%s", protocol, codec, compression),
+					name:    fmt.Sprintf("proxy/%s_%s_%s", protocol, codec, compression),
 					handler: wrapHandler(protocol, codec, compression, proxy),
 				})
 			}
@@ -167,6 +168,9 @@ func TestMux_RESTxRPC(t *testing.T) {
 			query[key] = values
 		}
 		req.URL.RawQuery = query.Encode()
+		// Inject http.Server into the request context for httputil.ReverseProxy.
+		svr := &http.Server{} //nolint:gosec // dummy server for testing
+		req = req.WithContext(context.WithValue(req.Context(), http.ServerContextKey, svr))
 		return req
 	}
 	type output struct {

--- a/vanguard_restxrpc_test.go
+++ b/vanguard_restxrpc_test.go
@@ -553,7 +553,7 @@ func TestMux_RESTxRPC(t *testing.T) {
 					rsp := httptest.NewRecorder()
 
 					func() {
-						// Capture http.ErrAbortHanlder panics.
+						// Capture http.ErrAbortHandler panics.
 						defer func() {
 							if recovered := recover(); recovered != nil {
 								if err, ok := recovered.(error); ok {

--- a/vanguard_restxrpc_test.go
+++ b/vanguard_restxrpc_test.go
@@ -73,11 +73,12 @@ func TestMux_RESTxRPC(t *testing.T) {
 		connect.WithInterceptors(&interceptor),
 	))
 
-	svr := httptest.NewServer(serveMux)
-	t.Cleanup(svr.Close)
-	svrURL, err := url.Parse(svr.URL)
+	server := httptest.NewServer(serveMux)
+	t.Cleanup(server.Close)
+	serverURL, err := url.Parse(server.URL)
 	require.NoError(t, err)
-	proxy := httputil.NewSingleHostReverseProxy(svrURL)
+	proxy := httputil.NewSingleHostReverseProxy(serverURL)
+	proxy.Transport = server.Client().Transport
 
 	type testMux struct {
 		name    string

--- a/vanguard_test.go
+++ b/vanguard_test.go
@@ -328,7 +328,7 @@ func (i *testInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 		diff := cmp.Diff(msg, inn.msg, protocmp.Transform())
 		if diff != "" {
 			stream.Error(diff)
-			return nil, fmt.Errorf("unexpected message diff")
+			return nil, errors.New("unexpected message diff")
 		}
 
 		if out.err != nil {

--- a/vanguard_test.go
+++ b/vanguard_test.go
@@ -327,7 +327,8 @@ func (i *testInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 		}
 		diff := cmp.Diff(msg, inn.msg, protocmp.Transform())
 		if diff != "" {
-			return nil, fmt.Errorf("message didn't match: %s", diff)
+			stream.Error(diff)
+			return nil, fmt.Errorf("unexpected message diff")
 		}
 
 		if out.err != nil {


### PR DESCRIPTION
Add test coverage for use of `httputil.ReverseProxy`. Currently on `Read` when we return a non `io.EOF` error it will cause the handler to panic which will incorrectly bubble up to the handler without encoding the error. Now we first report the error on prepare message before erroring the read with `io.EOF`.

Issues: 
- httputil suppress a panic [here](https://cs.opensource.google/go/go/+/master:src/net/http/httputil/reverseproxy.go;l=513) unless the server context key is set. This was a problem with how the rest tests the handler directly not the server implemenation. Add the key and ensure we handle the panic condition gracefully. 
- http2 transport errors on reading the body: https://cs.opensource.google/go/x/net/+/refs/tags/v0.18.0:http2/transport.go;l=1326
aborts the stream with the connect error given in the read. Should instead return `io.EOF` and cancel the context.