### PR TITLE
API improvements for dynamic usages

### DIFF
--- a/transcoder.go
+++ b/transcoder.go
@@ -176,20 +176,20 @@ func (t *Transcoder) registerMethod(handler http.Handler, methodDesc protoreflec
 	if _, ok := t.methods[methodPath]; ok {
 		return fmt.Errorf("duplicate registration: method %s has already been configured", methodDesc.FullName())
 	}
-	request, err := opts.resolver.FindMessageByName(methodDesc.Input().FullName())
+	requestType, err := opts.resolver.FindMessageByName(methodDesc.Input().FullName())
 	if err != nil {
-		request = dynamicpb.NewMessageType(methodDesc.Input())
+		requestType = dynamicpb.NewMessageType(methodDesc.Input())
 	}
-	response, err := opts.resolver.FindMessageByName(methodDesc.Output().FullName())
+	responseType, err := opts.resolver.FindMessageByName(methodDesc.Output().FullName())
 	if err != nil {
-		response = dynamicpb.NewMessageType(methodDesc.Output())
+		responseType = dynamicpb.NewMessageType(methodDesc.Output())
 	}
 
 	methodConf := &methodConfig{
 		serviceOptions: opts,
 		descriptor:     methodDesc,
-		request:        request,
-		response:       response,
+		requestType:    requestType,
+		responseType:   responseType,
 		methodPath:     methodPath,
 		handler:        handler,
 	}
@@ -514,7 +514,7 @@ func (o *operation) handle() {
 
 	if mustDecodeRequest {
 		// Need the message type to decode
-		reqMsg.msg = o.methodConf.request.New().Interface()
+		reqMsg.msg = o.methodConf.requestType.New().Interface()
 	}
 
 	if requireMessageForRequestLine {
@@ -1120,7 +1120,7 @@ func (w *responseWriter) WriteHeader(statusCode int) {
 
 	if mustDecodeResponse {
 		// We will have to decode and re-encode, so we need the message type.
-		respMsg.msg = w.op.methodConf.response.New().Interface()
+		respMsg.msg = w.op.methodConf.responseType.New().Interface()
 	}
 
 	var endMustBeInHeaders bool

--- a/transcoder.go
+++ b/transcoder.go
@@ -181,14 +181,14 @@ func (t *Transcoder) registerMethod(handler http.Handler, methodDesc protoreflec
 	if errors.Is(err, protoregistry.NotFound) {
 		requestType = dynamicpb.NewMessageType(methodDesc.Input())
 	} else if err != nil {
-		return fmt.Errorf("request type %s, for method %s, could not be resolved: %v",
+		return fmt.Errorf("request type %s, for method %s, could not be resolved: %w",
 			methodDesc.Input().FullName(), methodDesc.FullName(), err)
 	}
 	responseType, err := opts.resolver.FindMessageByName(methodDesc.Output().FullName())
 	if errors.Is(err, protoregistry.NotFound) {
 		responseType = dynamicpb.NewMessageType(methodDesc.Output())
 	} else if err != nil {
-		return fmt.Errorf("response type %s, for method %s, could not be resolved: %v",
+		return fmt.Errorf("response type %s, for method %s, could not be resolved: %w",
 			methodDesc.Output().FullName(), methodDesc.FullName(), err)
 	}
 

--- a/type_resolver.go
+++ b/type_resolver.go
@@ -1,0 +1,148 @@
+// Copyright 2023-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vanguard
+
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+// TypeResolver can resolve message and extension types and is used to instantiate
+// messages as needed for the middleware to serialize/de-serialize request and
+// response payloads.
+//
+// Implementations of this interface should be comparable, so they can be used as
+// map keys. Typical implementations are pointers to structs, which are suitable.
+type TypeResolver interface {
+	protoregistry.MessageTypeResolver
+	protoregistry.ExtensionTypeResolver
+}
+
+type fallbackResolver []TypeResolver
+
+func (f fallbackResolver) FindMessageByName(message protoreflect.FullName) (protoreflect.MessageType, error) {
+	var lastErr error
+	for _, res := range f {
+		msgType, err := res.FindMessageByName(message)
+		if err == nil {
+			return msgType, nil
+		}
+		lastErr = err
+	}
+	if lastErr == nil {
+		return nil, protoregistry.NotFound
+	}
+	return nil, lastErr
+}
+
+func (f fallbackResolver) FindMessageByURL(url string) (protoreflect.MessageType, error) {
+	var lastErr error
+	for _, res := range f {
+		msgType, err := res.FindMessageByURL(url)
+		if err == nil {
+			return msgType, nil
+		}
+		lastErr = err
+	}
+	if lastErr == nil {
+		return nil, protoregistry.NotFound
+	}
+	return nil, lastErr
+}
+
+func (f fallbackResolver) FindExtensionByName(field protoreflect.FullName) (protoreflect.ExtensionType, error) {
+	var lastErr error
+	for _, res := range f {
+		extType, err := res.FindExtensionByName(field)
+		if err == nil {
+			return extType, nil
+		}
+		lastErr = err
+	}
+	if lastErr == nil {
+		return nil, protoregistry.NotFound
+	}
+	return nil, lastErr
+}
+
+func (f fallbackResolver) FindExtensionByNumber(message protoreflect.FullName, field protoreflect.FieldNumber) (protoreflect.ExtensionType, error) {
+	var lastErr error
+	for _, res := range f {
+		extType, err := res.FindExtensionByNumber(message, field)
+		if err == nil {
+			return extType, nil
+		}
+		lastErr = err
+	}
+	if lastErr == nil {
+		return nil, protoregistry.NotFound
+	}
+	return nil, lastErr
+}
+
+func resolverForFile(file protoreflect.FileDescriptor) (TypeResolver, error) {
+	var files protoregistry.Files
+	if err := addFileRecursive(file, &files); err != nil {
+		return nil, fmt.Errorf("failed to create default resolver: %w", err)
+	}
+	return dynamicpb.NewTypes(&files), nil
+}
+
+func addFileRecursive(file protoreflect.FileDescriptor, files *protoregistry.Files) error {
+	if _, err := files.FindFileByPath(file.Path()); err == nil {
+		// already registered
+		return nil
+	}
+	if err := files.RegisterFile(file); err != nil {
+		return err
+	}
+	imports := file.Imports()
+	for i, length := 0, imports.Len(); i < length; i++ {
+		depFile := imports.Get(i).FileDescriptor
+		if err := addFileRecursive(depFile, files); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func canUseGlobalTypes(svcDesc protoreflect.ServiceDescriptor) bool {
+	file := svcDesc.ParentFile()
+	if file == nil {
+		return false
+	}
+	registeredFile, err := protoregistry.GlobalFiles.FindFileByPath(file.Path())
+	if err != nil || registeredFile != file {
+		return false
+	}
+	// It is possible for code to register files in the global registry but fail to
+	// register corresponding types in protoregistry.GlobalTypes. So before we return
+	// true, make sure that all of the service's request and response messages can
+	// actually be satisfied by the global types registry.
+	methods := svcDesc.Methods()
+	for i, length := 0, methods.Len(); i < length; i++ {
+		methodDesc := methods.Get(i)
+		if _, err := protoregistry.GlobalTypes.FindMessageByName(methodDesc.Input().FullName()); err != nil {
+			return false
+		}
+		if _, err := protoregistry.GlobalTypes.FindMessageByName(methodDesc.Output().FullName()); err != nil {
+			return false
+		}
+	}
+	return true
+}

--- a/type_resolver_test.go
+++ b/type_resolver_test.go
@@ -1,0 +1,138 @@
+// Copyright 2023-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vanguard
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"connectrpc.com/vanguard/internal/gen/vanguard/test/v1/testv1connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestCanUseGlobalTypes(t *testing.T) {
+	t.Parallel()
+	t.Run("service descriptor from global files", func(t *testing.T) {
+		t.Parallel()
+		desc, err := protoregistry.GlobalFiles.FindDescriptorByName(testv1connect.LibraryServiceName)
+		require.NoError(t, err)
+		svcDesc, ok := desc.(protoreflect.ServiceDescriptor)
+		require.True(t, ok)
+
+		assert.True(t, canUseGlobalTypes(svcDesc))
+	})
+	t.Run("service descriptor not from global files", func(t *testing.T) {
+		t.Parallel()
+		prefix := randomPrefix(t)
+		file, err := makeFile(prefix)
+		require.NoError(t, err)
+
+		svcDesc := file.Services().ByName("BlahService")
+		require.NotNil(t, svcDesc)
+
+		assert.False(t, canUseGlobalTypes(svcDesc))
+	})
+	t.Run("service descriptor from global files without types", func(t *testing.T) {
+		t.Parallel()
+		prefix := randomPrefix(t)
+		file, err := makeFile(prefix)
+		require.NoError(t, err)
+
+		svcDesc := file.Services().ByName("BlahService")
+		require.NotNil(t, svcDesc)
+
+		err = protoregistry.GlobalFiles.RegisterFile(file)
+		require.NoError(t, err)
+
+		// Now file is in GlobalFiles, but the request and response types are NOT in GlobalTypes.
+		// So this still returns false.
+		assert.False(t, canUseGlobalTypes(svcDesc))
+	})
+}
+
+func randomPrefix(t *testing.T) string {
+	t.Helper()
+	var prefixBytes [12]byte
+	_, err := rand.Read(prefixBytes[:])
+	require.NoError(t, err)
+	return "x" + hex.EncodeToString(prefixBytes[:])
+}
+
+func makeFile(prefix string) (protoreflect.FileDescriptor, error) {
+	pathPrefix := prefix
+	if pathPrefix != "" {
+		pathPrefix += "/"
+	}
+	pkgPrefix := prefix
+	if pkgPrefix != "" {
+		pkgPrefix += "."
+	}
+	var reg protoregistry.Files
+	err := reg.RegisterFile((*timestamppb.Timestamp)(nil).ProtoReflect().Descriptor().ParentFile())
+	if err != nil {
+		return nil, fmt.Errorf("failed to register dependency: %w", err)
+	}
+	return protodesc.NewFile(
+		&descriptorpb.FileDescriptorProto{
+			Name:       proto.String(pathPrefix + "foo/bar/baz/v1/blah.proto"),
+			Package:    proto.String(pkgPrefix + "foo.bar.baz.v1"),
+			Dependency: []string{"google/protobuf/timestamp.proto"},
+			MessageType: []*descriptorpb.DescriptorProto{
+				{
+					Name: proto.String("Blah"),
+				},
+				{
+					Name: proto.String("Blarg"),
+				},
+				{
+					Name: proto.String("Blech"),
+				},
+				{
+					Name: proto.String("Bleep"),
+				},
+				{
+					Name: proto.String("Blue"), // not actually used by service below
+				},
+			},
+			Service: []*descriptorpb.ServiceDescriptorProto{
+				{
+					Name: proto.String("BlahService"),
+					Method: []*descriptorpb.MethodDescriptorProto{
+						{
+							Name:       proto.String("Do"),
+							InputType:  proto.String("." + pkgPrefix + "foo.bar.baz.v1.Blah"),
+							OutputType: proto.String("." + pkgPrefix + "foo.bar.baz.v1.Blarg"),
+						},
+						{
+							Name:       proto.String("Dont"),
+							InputType:  proto.String("." + pkgPrefix + "foo.bar.baz.v1.Blech"),
+							OutputType: proto.String("." + pkgPrefix + "foo.bar.baz.v1.Bleep"),
+						},
+					},
+				},
+			},
+		},
+		&reg,
+	)
+}

--- a/type_resolver_test.go
+++ b/type_resolver_test.go
@@ -33,7 +33,7 @@ import (
 
 func TestCanUseGlobalTypes(t *testing.T) {
 	t.Parallel()
-	t.Run("service descriptor from global files", func(t *testing.T) {
+	t.Run("service_descriptor_from_global_files", func(t *testing.T) {
 		t.Parallel()
 		desc, err := protoregistry.GlobalFiles.FindDescriptorByName(testv1connect.LibraryServiceName)
 		require.NoError(t, err)
@@ -42,7 +42,7 @@ func TestCanUseGlobalTypes(t *testing.T) {
 
 		assert.True(t, canUseGlobalTypes(svcDesc))
 	})
-	t.Run("service descriptor not from global files", func(t *testing.T) {
+	t.Run("service_descriptor_not_from_global_files", func(t *testing.T) {
 		t.Parallel()
 		prefix := randomPrefix(t)
 		file, err := makeFile(prefix)
@@ -53,7 +53,7 @@ func TestCanUseGlobalTypes(t *testing.T) {
 
 		assert.False(t, canUseGlobalTypes(svcDesc))
 	})
-	t.Run("service descriptor from global files without types", func(t *testing.T) {
+	t.Run("service_descriptor_from_global_files_without_types", func(t *testing.T) {
 		t.Parallel()
 		prefix := randomPrefix(t)
 		file, err := makeFile(prefix)

--- a/vanguard.go
+++ b/vanguard.go
@@ -424,12 +424,12 @@ type serviceOptions struct {
 
 type methodConfig struct {
 	*serviceOptions
-	descriptor        protoreflect.MethodDescriptor
-	request, response protoreflect.MessageType
-	methodPath        string
-	streamType        connect.StreamType
-	handler           http.Handler
-	httpRule          *routeTarget // First HTTP rule, if any.
+	descriptor                protoreflect.MethodDescriptor
+	requestType, responseType protoreflect.MessageType
+	methodPath                string
+	streamType                connect.StreamType
+	handler                   http.Handler
+	httpRule                  *routeTarget // First HTTP rule, if any.
 }
 
 func descKind(desc protoreflect.Descriptor) string {

--- a/vanguard_test.go
+++ b/vanguard_test.go
@@ -107,7 +107,7 @@ func TestServiceWithSchema(t *testing.T) {
 			WithTypeResolver(protoregistry.GlobalTypes),
 		)
 
-		_, err = NewTranscoder([]*Service{svc})
+		_, err := NewTranscoder([]*Service{svc})
 		require.ErrorContains(t, err, "resolver configured for service foo.bar.baz.v1.BlahService cannot resolve")
 	})
 	t.Run("fails for rest only but no http rules", func(t *testing.T) {
@@ -118,7 +118,7 @@ func TestServiceWithSchema(t *testing.T) {
 			WithTargetProtocols(ProtocolREST),
 		)
 
-		_, err = NewTranscoder([]*Service{svc})
+		_, err := NewTranscoder([]*Service{svc})
 		require.ErrorContains(t, err, "service foo.bar.baz.v1.BlahService only supports REST target protocol but has no methods with HTTP rules")
 	})
 }

--- a/vanguard_test.go
+++ b/vanguard_test.go
@@ -57,7 +57,7 @@ func TestServiceWithSchema(t *testing.T) {
 	svcDesc := file.Services().ByName("BlahService")
 	require.NotNil(t, svcDesc)
 
-	t.Run("default bespoke resolver", func(t *testing.T) {
+	t.Run("default_bespoke_resolver", func(t *testing.T) {
 		t.Parallel()
 		svc := NewServiceWithSchema(svcDesc, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 
@@ -77,7 +77,7 @@ func TestServiceWithSchema(t *testing.T) {
 		_, ok := timestampType.New().Interface().(*dynamicpb.Message)
 		assert.True(t, ok)
 	})
-	t.Run("default bespoke resolver, service has no parent file", func(t *testing.T) {
+	t.Run("default_bespoke_resolver_service_has_no_parent_file", func(t *testing.T) {
 		t.Parallel()
 		svcDescNoParent := &serviceWithNoParentFile{ServiceDescriptor: svcDesc}
 		svc := NewServiceWithSchema(svcDescNoParent, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
@@ -98,7 +98,7 @@ func TestServiceWithSchema(t *testing.T) {
 		_, ok := timestampType.New().Interface().(*timestamppb.Timestamp)
 		assert.True(t, ok)
 	})
-	t.Run("uses dynamic message type with bad resolver", func(t *testing.T) {
+	t.Run("uses_dynamic_message_type_with_bad_resolver", func(t *testing.T) {
 		t.Parallel()
 		svc := NewServiceWithSchema(
 			svcDesc,
@@ -123,7 +123,7 @@ func TestServiceWithSchema(t *testing.T) {
 		_, ok := timestampType.New().Interface().(*timestamppb.Timestamp)
 		assert.True(t, ok)
 	})
-	t.Run("fails for rest only because no http rules", func(t *testing.T) {
+	t.Run("fails_for_rest_only_because_no_http_rules", func(t *testing.T) {
 		t.Parallel()
 		svc := NewServiceWithSchema(
 			svcDesc,

--- a/vanguard_test.go
+++ b/vanguard_test.go
@@ -38,12 +38,79 @@ import (
 	"google.golang.org/genproto/googleapis/api/annotations"
 	"google.golang.org/genproto/googleapis/api/httpbody"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/dynamicpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (
 	defaultTestTimeout = 30 * time.Second
 )
+
+func TestServiceWithSchema(t *testing.T) {
+	t.Parallel()
+	file, err := makeFile("")
+	require.NoError(t, err)
+
+	svcDesc := file.Services().ByName("BlahService")
+	require.NotNil(t, svcDesc)
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		svc := NewServiceWithSchema(svcDesc, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+		// Make sure we can validate the service and that the default resolver is able to
+		// correctly resolve request and response types.
+		transcoder, err := NewTranscoder([]*Service{svc})
+		require.NoError(t, err)
+
+		res := transcoder.methods["/"+string(svcDesc.FullName())+"/Do"].resolver
+		// Resolver can also resolve other messages in the file.
+		_, err = res.FindMessageByName("foo.bar.baz.v1.Blue")
+		require.NoError(t, err)
+		// And it can resolve anything in the service file's transitive dependencies.
+		timestampType, err := res.FindMessageByName("google.protobuf.Timestamp")
+		require.NoError(t, err)
+		// All types are dynamic.
+		_, ok := timestampType.New().Interface().(*dynamicpb.Message)
+		assert.True(t, ok)
+	})
+	t.Run("service has no parent file", func(t *testing.T) {
+		t.Parallel()
+		svcDescNoParent := &serviceWithNoParentFile{ServiceDescriptor: svcDesc}
+		svc := NewServiceWithSchema(svcDescNoParent, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+		// Still works.
+		transcoder, err := NewTranscoder([]*Service{svc})
+		require.NoError(t, err)
+
+		res := transcoder.methods["/"+string(svcDesc.FullName())+"/Do"].resolver
+		// But the resolve can only resolve the request and response types.
+		// It cannot resolve other types that were in the same file.
+		_, err = res.FindMessageByName("foo.bar.baz.v1.Blue")
+		require.ErrorIs(t, err, protoregistry.NotFound)
+		// This type can be resolved, because the default resolver will fallback to global types.
+		timestampType, err := res.FindMessageByName("google.protobuf.Timestamp")
+		require.NoError(t, err)
+		// But since it is from global types, it is NOT a dynamic message type.
+		_, ok := timestampType.New().Interface().(*timestamppb.Timestamp)
+		assert.True(t, ok)
+	})
+	t.Run("fails with bad resolver", func(t *testing.T) {
+		t.Parallel()
+		svc := NewServiceWithSchema(
+			svcDesc,
+			http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
+			// Global registry doesn't know about these dynamic types.
+			WithTypeResolver(protoregistry.GlobalTypes),
+		)
+
+		_, err = NewTranscoder([]*Service{svc})
+		require.ErrorContains(t, err, "resolver configured for service foo.bar.baz.v1.BlahService cannot resolve")
+	})
+}
 
 func TestRuleSelector(t *testing.T) {
 	t.Parallel()
@@ -983,5 +1050,17 @@ func assertTestTimeoutEncoded(ctx context.Context) error {
 	if deadline.Before(now.Add(defaultTestTimeout - 5*time.Second)) {
 		return errors.New("context deadline should be at least 20 seconds")
 	}
+	return nil
+}
+
+type serviceWithNoParentFile struct {
+	protoreflect.ServiceDescriptor
+}
+
+func (s *serviceWithNoParentFile) ParentFile() protoreflect.FileDescriptor {
+	return nil
+}
+
+func (s *serviceWithNoParentFile) Parent() protoreflect.Descriptor {
 	return nil
 }

--- a/vanguard_test.go
+++ b/vanguard_test.go
@@ -110,6 +110,17 @@ func TestServiceWithSchema(t *testing.T) {
 		_, err = NewTranscoder([]*Service{svc})
 		require.ErrorContains(t, err, "resolver configured for service foo.bar.baz.v1.BlahService cannot resolve")
 	})
+	t.Run("fails for rest only but no http rules", func(t *testing.T) {
+		t.Parallel()
+		svc := NewServiceWithSchema(
+			svcDesc,
+			http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
+			WithTargetProtocols(ProtocolREST),
+		)
+
+		_, err = NewTranscoder([]*Service{svc})
+		require.ErrorContains(t, err, "service foo.bar.baz.v1.BlahService only supports REST target protocol but has no methods with HTTP rules")
+	})
 }
 
 func TestRuleSelector(t *testing.T) {

--- a/vanguard_test.go
+++ b/vanguard_test.go
@@ -56,6 +56,7 @@ func TestServiceWithSchema(t *testing.T) {
 
 	svcDesc := file.Services().ByName("BlahService")
 	require.NotNil(t, svcDesc)
+	methodPath := "/" + string(svcDesc.FullName()) + "/Do"
 
 	t.Run("default_bespoke_resolver", func(t *testing.T) {
 		t.Parallel()
@@ -66,7 +67,7 @@ func TestServiceWithSchema(t *testing.T) {
 		transcoder, err := NewTranscoder([]*Service{svc})
 		require.NoError(t, err)
 
-		res := transcoder.methods["/"+string(svcDesc.FullName())+"/Do"].resolver
+		res := transcoder.methods[methodPath].resolver
 		// Resolver can also resolve other messages in the file.
 		_, err = res.FindMessageByName("foo.bar.baz.v1.Blue")
 		require.NoError(t, err)
@@ -87,7 +88,7 @@ func TestServiceWithSchema(t *testing.T) {
 		transcoder, err := NewTranscoder([]*Service{svc})
 		require.NoError(t, err)
 
-		res := transcoder.methods["/"+string(svcDesc.FullName())+"/Do"].resolver
+		res := transcoder.methods[methodPath].resolver
 		// It cannot resolve other types that were in the same file.
 		_, err = res.FindMessageByName("foo.bar.baz.v1.Blue")
 		require.ErrorIs(t, err, protoregistry.NotFound)
@@ -112,7 +113,7 @@ func TestServiceWithSchema(t *testing.T) {
 		transcoder, err := NewTranscoder([]*Service{svc})
 		require.NoError(t, err)
 
-		res := transcoder.methods["/"+string(svcDesc.FullName())+"/Do"].resolver
+		res := transcoder.methods[methodPath].resolver
 		// It cannot resolve other types that were in the same file.
 		_, err = res.FindMessageByName("foo.bar.baz.v1.Blue")
 		require.ErrorIs(t, err, protoregistry.NotFound)


### PR DESCRIPTION
In light of recent experience report using this module with a dynamic schema, this PR proposes several changes to make such work easier. It also puts additional validation into initialization, so we can fail faster and (hopefully) with better error messages.

1. Don't make user provide a type resolver. If user does not provide a type resolver with a custom schema, use a smarter default that can use dynamic message types and then fallback to the global registry for anything unknown (including both extensions and message types).
2. Validate during initialization that the given type resolver can actually resolve all of the methods' request and response types.

There is also a small change in here that is not strictly related to dynamic usage but is instead related to proxying an RPC protocol to REST: if a request comes in via RPC protocol for a method that has no HTTP mapping and the target protocol is REST, this will now return a "404 not found" status code. It previously could result in a nil-dereference panic.