### PR TITLE
Bump Go to v1.22

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.19.x, 1.20.x, 1.21.x]
+        go-version: [1.20.x, 1.21.x, 1.22.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -32,5 +32,5 @@ jobs:
         # conflicting guidance, run only on the most recent supported version.
         # For the same reason, only check generated code on the most recent
         # supported version.
-        if: matrix.go-version == '1.21.x'
+        if: matrix.go-version == '1.22.x'
         run: make checkgenerate && make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,6 +45,7 @@ linters:
     - golint            # deprecated by Go team
     - gomnd             # some unnamed constants are okay
     - ifshort           # deprecated by author
+    - inamedparam       # convention is not followed
     - interfacer        # deprecated by author
     - ireturn           # "accept interfaces, return structs" isn't ironclad
     - lll               # don't want hard limits for line length

--- a/Makefile
+++ b/Makefile
@@ -81,13 +81,13 @@ checkgenerate:
 $(BIN)/buf: Makefile
 	@mkdir -p $(@D)
 	GOBIN=$(abspath $(@D)) $(GO) install \
-		  github.com/bufbuild/buf/cmd/buf@v1.26.0
+		  github.com/bufbuild/buf/cmd/buf@v1.29.0
 
 $(BIN)/license-header: Makefile
 	@mkdir -p $(@D)
 	GOBIN=$(abspath $(@D)) $(GO) install \
-		  github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@v1.26.0
+		  github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@v1.29.0
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
+	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module connectrpc.com/vanguard
 
-go 1.19
+go 1.20
 
 require (
 	buf.build/gen/go/connectrpc/eliza/connectrpc/go v1.11.1-20230822171018-8b8b971d6fde.1

--- a/internal/examples/connect-grpc/cmd/client/main.go
+++ b/internal/examples/connect-grpc/cmd/client/main.go
@@ -47,7 +47,7 @@ func main() {
 		os.Exit(1)
 	}
 	for stream.Receive() {
-		fmt.Println("eliza: ", stream.Msg().Sentence)
+		fmt.Println("eliza: ", stream.Msg().GetSentence())
 	}
 	if err := stream.Err(); err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, err)
@@ -70,7 +70,7 @@ func main() {
 			_, _ = fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
-		fmt.Println("eliza: ", resp.Msg.Sentence)
+		fmt.Println("eliza: ", resp.Msg.GetSentence())
 		fmt.Println()
 	}
 }

--- a/internal/examples/fileserver/main.go
+++ b/internal/examples/fileserver/main.go
@@ -82,7 +82,7 @@ type ContentService struct {
 }
 
 func (c *ContentService) Index(_ context.Context, req *connect.Request[testv1.IndexRequest]) (*connect.Response[httpbody.HttpBody], error) {
-	name := req.Msg.Page
+	name := req.Msg.GetPage()
 	log.Printf("Index: %v", name)
 	if name == "/" || name == "" {
 		name = "."

--- a/path_parser.go
+++ b/path_parser.go
@@ -97,10 +97,10 @@ func (p *pathParser) errSyntax(msg string) error {
 	return fmt.Errorf("syntax error at column %v: %s", p.scan.pos, msg)
 }
 func (p *pathParser) errUnexpected() error {
-	return p.errSyntax(fmt.Sprintf("unexpected %s", p.currentChar()))
+	return p.errSyntax("unexpected " + p.currentChar())
 }
 func (p *pathParser) errExpected(expected rune) error {
-	return p.errSyntax(fmt.Sprintf("expected %q, got %s", expected, p.currentChar()))
+	return p.errSyntax("expected " + strconv.QuoteRune(expected) + ", got " + p.currentChar())
 }
 
 func (p *pathParser) parseTemplate() error {

--- a/path_parser_test.go
+++ b/path_parser_test.go
@@ -256,7 +256,7 @@ func TestPath_SafeLiterals(t *testing.T) {
 		}
 	}
 	unescaped, err := url.PathUnescape(literalvalues)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	escaped := url.PathEscape(unescaped)
 	assert.Equal(t, literalvalues, escaped)
 }
@@ -300,7 +300,7 @@ func TestPath_Escaping(t *testing.T) {
 				assert.EqualError(t, err, testCase.wantErr)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, testCase.want, dec)
 			enc := pathEscape(dec, testCase.mode)
 			if testCase.wantEscaped != "" {

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -37,8 +37,9 @@ import (
 )
 
 const (
-	contentTypeJSON      = "application/json"
-	contentConnectPrefix = "application/connect+"
+	contentTypeJSON            = "application/json"
+	contentConnectStreamPrefix = "application/connect+"
+	contentConnectUnaryPrefix  = "application/"
 )
 
 // connectUnaryGetClientProtocol implements the Connect protocol for
@@ -177,7 +178,7 @@ func (c connectUnaryPostClientProtocol) extractProtocolRequestHeaders(_ *operati
 	if err := connectExtractTimeout(headers, &reqMeta); err != nil {
 		return reqMeta, err
 	}
-	reqMeta.codec = strings.TrimPrefix(headers.Get("Content-Type"), contentApplicationPrefix)
+	reqMeta.codec = strings.TrimPrefix(headers.Get("Content-Type"), contentConnectUnaryPrefix)
 	if reqMeta.codec == CodecJSON+"; charset=utf-8" {
 		// TODO: should we support other text formats that may need charset check?
 		reqMeta.codec = CodecJSON
@@ -198,7 +199,7 @@ func (c connectUnaryPostClientProtocol) addProtocolResponseHeaders(meta response
 		headers.Set("Content-Type", contentTypeJSON) // error bodies are always in JSON
 		// TODO: Content-Encoding to compress error?
 	} else {
-		headers.Set("Content-Type", contentApplicationPrefix+meta.codec)
+		headers.Set("Content-Type", contentConnectUnaryPrefix+meta.codec)
 		if meta.compression != "" {
 			headers.Set("Content-Encoding", meta.compression)
 		}
@@ -251,7 +252,7 @@ func (c connectUnaryServerProtocol) protocol() Protocol {
 }
 
 func (c connectUnaryServerProtocol) addProtocolRequestHeaders(meta requestMeta, headers http.Header) {
-	headers.Set("Content-Type", contentApplicationPrefix+meta.codec)
+	headers.Set("Content-Type", contentConnectUnaryPrefix+meta.codec)
 	if meta.compression != "" {
 		headers.Set("Content-Encoding", meta.compression)
 	}
@@ -271,8 +272,8 @@ func (c connectUnaryServerProtocol) extractProtocolResponseHeaders(statusCode in
 	var respMeta responseMeta
 	contentType := headers.Get("Content-Type")
 	switch {
-	case strings.HasPrefix(contentType, contentApplicationPrefix):
-		respMeta.codec = strings.TrimPrefix(contentType, contentApplicationPrefix)
+	case strings.HasPrefix(contentType, contentConnectUnaryPrefix):
+		respMeta.codec = strings.TrimPrefix(contentType, contentConnectUnaryPrefix)
 	default:
 		respMeta.codec = contentType + "?"
 	}
@@ -420,7 +421,7 @@ func (c connectStreamClientProtocol) extractProtocolRequestHeaders(_ *operation,
 	if err := connectExtractTimeout(headers, &reqMeta); err != nil {
 		return reqMeta, err
 	}
-	reqMeta.codec = strings.TrimPrefix(headers.Get("Content-Type"), contentConnectPrefix)
+	reqMeta.codec = strings.TrimPrefix(headers.Get("Content-Type"), contentConnectStreamPrefix)
 	headers.Del("Content-Type")
 	reqMeta.compression = headers.Get("Connect-Content-Encoding")
 	headers.Del("Connect-Content-Encoding")
@@ -430,7 +431,7 @@ func (c connectStreamClientProtocol) extractProtocolRequestHeaders(_ *operation,
 }
 
 func (c connectStreamClientProtocol) addProtocolResponseHeaders(meta responseMeta, headers http.Header) int {
-	headers.Set("Content-Type", contentConnectPrefix+meta.codec)
+	headers.Set("Content-Type", contentConnectStreamPrefix+meta.codec)
 	if meta.compression != "" {
 		headers.Set("Connect-Content-Encoding", meta.compression)
 	}
@@ -498,7 +499,7 @@ func (c connectStreamServerProtocol) protocol() Protocol {
 }
 
 func (c connectStreamServerProtocol) addProtocolRequestHeaders(meta requestMeta, headers http.Header) {
-	headers.Set("Content-Type", contentConnectPrefix+meta.codec)
+	headers.Set("Content-Type", contentConnectStreamPrefix+meta.codec)
 	if meta.compression != "" {
 		headers.Set("Connect-Content-Encoding", meta.compression)
 	}
@@ -514,8 +515,8 @@ func (c connectStreamServerProtocol) extractProtocolResponseHeaders(statusCode i
 	var respMeta responseMeta
 	contentType := headers.Get("Content-Type")
 	switch {
-	case strings.HasPrefix(contentType, contentConnectPrefix):
-		respMeta.codec = strings.TrimPrefix(contentType, contentConnectPrefix)
+	case strings.HasPrefix(contentType, contentConnectStreamPrefix):
+		respMeta.codec = strings.TrimPrefix(contentType, contentConnectStreamPrefix)
 	default:
 		respMeta.codec = contentType + "?"
 	}

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -544,8 +544,8 @@ func grpcExtractErrorFromTrailer(trailers http.Header) *connect.Error {
 			protocolError("invalid protobuf for error details: %w", err),
 		)
 	}
-	trailerErr := connect.NewWireError(connect.Code(stat.Code), errors.New(stat.Message))
-	for _, msg := range stat.Details {
+	trailerErr := connect.NewWireError(connect.Code(stat.GetCode()), errors.New(stat.GetMessage()))
+	for _, msg := range stat.GetDetails() {
 		errDetail, err := connect.NewErrorDetail(msg)
 		if err != nil {
 			// shouldn't happen since msg is an Any and doesn't need to be marshalled

--- a/protocol_grpc_test.go
+++ b/protocol_grpc_test.go
@@ -15,6 +15,7 @@
 package vanguard
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"net/http/httptest"
@@ -115,14 +116,14 @@ func TestGRPCDecodeTimeout(t *testing.T) {
 	require.ErrorIs(t, err, errNoTimeout)
 
 	_, err = grpcDecodeTimeout("foo")
-	require.NoError(t, err)
+	assert.Error(t, err) //nolint:testifylint
 	_, err = grpcDecodeTimeout("12xS")
-	require.NoError(t, err)
-	_, err = grpcDecodeTimeout("999999999n") // 9 digits
-	require.NoError(t, err)
-	require.ErrorIs(t, err, errNoTimeout)
-	_, err = grpcDecodeTimeout("99999999H") // 8 digits but overflows time.Duration
-	require.ErrorIs(t, err, errNoTimeout)
+	assert.Error(t, err)                          //nolint:testifylint
+	_, err = grpcDecodeTimeout("999999999n")      // 9 digits
+	assert.Error(t, err)                          //nolint:testifylint
+	assert.False(t, errors.Is(err, errNoTimeout)) //nolint:testifylint
+	_, err = grpcDecodeTimeout("99999999H")       // 8 digits but overflows time.Duration
+	assert.ErrorIs(t, err, errNoTimeout)          //nolint:testifylint
 
 	duration, err := grpcDecodeTimeout("45S")
 	require.NoError(t, err)

--- a/protocol_grpc_test.go
+++ b/protocol_grpc_test.go
@@ -15,7 +15,6 @@
 package vanguard
 
 import (
-	"errors"
 	"fmt"
 	"math"
 	"net/http/httptest"
@@ -42,7 +41,7 @@ func TestGRPCErrorWriter(t *testing.T) {
 	assert.Equal(t, "test error: Hello, %E4%B8%96%E7%95%8C", rec.Header().Get("Grpc-Message"))
 	// if error has no details, no need to generate this response trailer
 	assert.Equal(t, "", rec.Header().Get("Grpc-Status-Details-Bin"))
-	assert.Len(t, rec.Body.Bytes(), 0)
+	assert.Empty(t, rec.Body.Bytes())
 
 	got := grpcExtractErrorFromTrailer(rec.Header())
 	assert.Equal(t, cerr, got)
@@ -57,7 +56,7 @@ func TestGRPCErrorWriter(t *testing.T) {
 	assert.Equal(t, "16", rec.Header().Get("Grpc-Status"))
 	assert.Equal(t, "test error: Hello, %E4%B8%96%E7%95%8C", rec.Header().Get("Grpc-Message"))
 	assert.Equal(t, "CBASGXRlc3QgZXJyb3I6IEhlbGxvLCDkuJbnlYwaOAovdHlwZS5nb29nbGVhcGlzLmNvbS9nb29nbGUucHJvdG9idWYuU3RyaW5nVmFsdWUSBQoDZm9v", rec.Header().Get("Grpc-Status-Details-Bin"))
-	assert.Len(t, rec.Body.Bytes(), 0)
+	assert.Empty(t, rec.Body.Bytes())
 
 	got = grpcExtractErrorFromTrailer(rec.Header())
 	assert.Equal(t, cerr, got)
@@ -113,34 +112,34 @@ func TestGRPCPercentEncoding(t *testing.T) {
 func TestGRPCDecodeTimeout(t *testing.T) {
 	t.Parallel()
 	_, err := grpcDecodeTimeout("")
-	assert.True(t, errors.Is(err, errNoTimeout))
+	require.ErrorIs(t, err, errNoTimeout)
 
 	_, err = grpcDecodeTimeout("foo")
-	assert.NotNil(t, err)
+	require.NoError(t, err)
 	_, err = grpcDecodeTimeout("12xS")
-	assert.NotNil(t, err)
+	require.NoError(t, err)
 	_, err = grpcDecodeTimeout("999999999n") // 9 digits
-	assert.NotNil(t, err)
-	assert.False(t, errors.Is(err, errNoTimeout))
+	require.NoError(t, err)
+	require.ErrorIs(t, err, errNoTimeout)
 	_, err = grpcDecodeTimeout("99999999H") // 8 digits but overflows time.Duration
-	assert.True(t, errors.Is(err, errNoTimeout))
+	require.ErrorIs(t, err, errNoTimeout)
 
 	duration, err := grpcDecodeTimeout("45S")
-	assert.Nil(t, err)
-	assert.Equal(t, duration, 45*time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, 45*time.Second, duration)
 
 	const long = "99999999S"
 	duration, err = grpcDecodeTimeout(long) // 8 digits, shouldn't overflow
-	assert.Nil(t, err)
-	assert.Equal(t, duration, 99999999*time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, 99999999*time.Second, duration)
 }
 
 func TestGRPCEncodeTimeout(t *testing.T) {
 	t.Parallel()
 	timeout := grpcEncodeTimeout(time.Hour + time.Second)
-	assert.Equal(t, timeout, "3601000m")
+	assert.Equal(t, "3601000m", timeout)
 	timeout = grpcEncodeTimeout(time.Duration(math.MaxInt64))
-	assert.Equal(t, timeout, "2562047H")
+	assert.Equal(t, "2562047H", timeout)
 	timeout = grpcEncodeTimeout(-1 * time.Hour)
-	assert.Equal(t, timeout, "0n")
+	assert.Equal(t, "0n", timeout)
 }

--- a/protocol_http.go
+++ b/protocol_http.go
@@ -33,10 +33,6 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
-const (
-	contentApplicationPrefix = "application/"
-)
-
 func httpStatusCodeFromRPC(code connect.Code) int {
 	var codes = [...]int{
 		http.StatusOK,                  // 0 OK

--- a/protocol_http.go
+++ b/protocol_http.go
@@ -33,6 +33,10 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
+const (
+	contentApplicationPrefix = "application/"
+)
+
 func httpStatusCodeFromRPC(code connect.Code) int {
 	var codes = [...]int{
 		http.StatusOK,                  // 0 OK
@@ -120,10 +124,10 @@ func httpErrorFromResponse(statusCode int, contentType string, src *bytes.Buffer
 	}
 
 	connectErr := connect.NewWireError(
-		connect.Code(stat.Code),
-		errors.New(stat.Message),
+		connect.Code(stat.GetCode()),
+		errors.New(stat.GetMessage()),
 	)
-	for _, msg := range stat.Details {
+	for _, msg := range stat.GetDetails() {
 		errDetail, _ := connect.NewErrorDetail(msg)
 		connectErr.AddDetail(errDetail)
 	}

--- a/protocol_rest.go
+++ b/protocol_rest.go
@@ -28,6 +28,10 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
+const (
+	contentRestPrefix = "application/"
+)
+
 type restClientProtocol struct{}
 
 var _ clientProtocolHandler = restClientProtocol{}
@@ -97,7 +101,7 @@ func (r restClientProtocol) addProtocolResponseHeaders(meta responseMeta, header
 	// Only JSON is supported for now unless using google.api.HttpBody
 	// payloads which override the content-type.
 	if headers["Content-Type"] == nil {
-		headers["Content-Type"] = []string{contentApplicationPrefix + meta.codec}
+		headers["Content-Type"] = []string{contentRestPrefix + meta.codec}
 	}
 	if !isErr && meta.compression != "" {
 		headers["Content-Encoding"] = []string{meta.compression}
@@ -261,7 +265,7 @@ func (r restServerProtocol) protocol() Protocol {
 
 func (r restServerProtocol) addProtocolRequestHeaders(meta requestMeta, headers http.Header) {
 	// TODO: don't set content-type on no body requests.
-	headers["Content-Type"] = []string{contentApplicationPrefix + meta.codec}
+	headers["Content-Type"] = []string{contentRestPrefix + meta.codec}
 	if meta.compression != "" {
 		headers["Content-Encoding"] = []string{meta.compression}
 	}

--- a/protocol_rest.go
+++ b/protocol_rest.go
@@ -97,7 +97,7 @@ func (r restClientProtocol) addProtocolResponseHeaders(meta responseMeta, header
 	// Only JSON is supported for now unless using google.api.HttpBody
 	// payloads which override the content-type.
 	if headers["Content-Type"] == nil {
-		headers["Content-Type"] = []string{"application/" + meta.codec}
+		headers["Content-Type"] = []string{contentApplicationPrefix + meta.codec}
 	}
 	if !isErr && meta.compression != "" {
 		headers["Content-Encoding"] = []string{meta.compression}
@@ -261,7 +261,7 @@ func (r restServerProtocol) protocol() Protocol {
 
 func (r restServerProtocol) addProtocolRequestHeaders(meta requestMeta, headers http.Header) {
 	// TODO: don't set content-type on no body requests.
-	headers["Content-Type"] = []string{"application/" + meta.codec}
+	headers["Content-Type"] = []string{contentApplicationPrefix + meta.codec}
 	if meta.compression != "" {
 		headers["Content-Encoding"] = []string{meta.compression}
 	}

--- a/transcoder.go
+++ b/transcoder.go
@@ -140,7 +140,7 @@ func (t *Transcoder) registerRules(rules []*annotations.HttpRule) error {
 		var applied bool
 		selector := rule.GetSelector()
 		if selector == "" {
-			return fmt.Errorf("rule missing selector")
+			return errors.New("rule missing selector")
 		}
 		if i := strings.Index(selector, "*"); i >= 0 {
 			if i != len(selector)-1 {
@@ -216,8 +216,8 @@ func (t *Transcoder) addRule(httpRule *annotations.HttpRule, methodConf *methodC
 		return fmt.Errorf("failed to add REST route for method %s: %w", methodPath, err)
 	}
 	methodConf.httpRule = firstTarget
-	for i, rule := range httpRule.AdditionalBindings {
-		if len(rule.AdditionalBindings) > 0 {
+	for i, rule := range httpRule.GetAdditionalBindings() {
+		if len(rule.GetAdditionalBindings()) > 0 {
 			return fmt.Errorf("nested additional bindings are not supported (method %s)", methodPath)
 		}
 		if _, err := t.restRoutes.addRoute(methodConf, rule); err != nil {
@@ -729,7 +729,7 @@ func (o *operation) processRequestEnvelope(envBuf envelopeBytes) (msgLen int, co
 		return 0, false, malformedRequestError(err)
 	}
 	if env.trailer {
-		return 0, false, malformedRequestError(fmt.Errorf("client stream cannot include status/trailer message"))
+		return 0, false, malformedRequestError(errors.New("client stream cannot include status/trailer message"))
 	}
 	if limit := o.methodConf.maxMsgBufferBytes; env.length > limit {
 		return 0, false, bufferLimitError(int64(limit))

--- a/transcoder_bench_test.go
+++ b/transcoder_bench_test.go
@@ -62,14 +62,14 @@ func BenchmarkServeHTTP(b *testing.B) {
 	}
 	marshalJSON := func(msg proto.Message) []byte {
 		data, err := jsonCodec.MarshalAppend(nil, msg)
-		assert.NoError(b, err)
+		require.NoError(b, err)
 		var buf bytes.Buffer
-		assert.NoError(b, json.Compact(&buf, data))
+		require.NoError(b, json.Compact(&buf, data))
 		return buf.Bytes()
 	}
 	marshalProto := func(msg proto.Message) []byte {
 		data, err := proto.Marshal(msg)
-		assert.NoError(b, err)
+		require.NoError(b, err)
 		return data
 	}
 
@@ -88,16 +88,16 @@ func BenchmarkServeHTTP(b *testing.B) {
 	reqMsgProto := marshalProto(reqMsg)
 	reqMsgProtoComp := compress(reqMsgProto)
 	reqMsgJSON := marshalJSON(reqMsg)
-	reqMsgBookJSON := marshalJSON(reqMsg.Book)
+	reqMsgBookJSON := marshalJSON(reqMsg.GetBook())
 
 	rspMsg := &testv1.Book{
 		Name:        "books/123",
 		Parent:      "shelves/456",
-		CreateTime:  reqMsg.Book.CreateTime,
+		CreateTime:  reqMsg.GetBook().GetCreateTime(),
 		UpdateTime:  timestamppb.New(time.Date(2023, 9, 1, 0, 0, 0, 0, time.UTC)),
-		Title:       reqMsg.Book.Title,
-		Author:      reqMsg.Book.Author,
-		Description: reqMsg.Book.Description,
+		Title:       reqMsg.GetBook().GetTitle(),
+		Author:      reqMsg.GetBook().GetAuthor(),
+		Description: reqMsg.GetBook().GetDescription(),
 		Labels: map[string]string{
 			"genre": "science fiction",
 		},
@@ -205,7 +205,7 @@ func BenchmarkServeHTTP(b *testing.B) {
 				assert.Equal(b, "application/json", rsp.Header().Get("Content-Type"), "response content type")
 				data := rsp.Body.Bytes()
 				rsp.Body.Reset()
-				assert.NoError(b, json.Compact(rsp.Body, data))
+				require.NoError(b, json.Compact(rsp.Body, data))
 				assert.Equal(b, rspMsgJSON, rsp.Body.Bytes(), "response body")
 			}
 		})
@@ -293,7 +293,7 @@ func BenchmarkServeHTTP(b *testing.B) {
 			assert.Equal(b, "application/json", rsp.Header().Get("Content-Type"), "response content type")
 			data := rsp.Body.Bytes()
 			rsp.Body.Reset()
-			assert.NoError(b, json.Compact(rsp.Body, data))
+			require.NoError(b, json.Compact(rsp.Body, data))
 			assert.Equal(b, rspMsgJSON, rsp.Body.Bytes(), "response body")
 		}
 		b.StopTimer()

--- a/transcoder_test.go
+++ b/transcoder_test.go
@@ -89,7 +89,7 @@ func TestTranscoder_BufferTooLargeFails(t *testing.T) {
 	}{
 		{
 			name: "enveloping_reader",
-			expectation: func(t *testing.T, rw http.ResponseWriter, req *http.Request) {
+			expectation: func(t *testing.T, _ http.ResponseWriter, req *http.Request) {
 				t.Helper()
 				_, ok := req.Body.(*envelopingReader)
 				assert.True(t, ok, "request body should be *envelopingReader")
@@ -114,7 +114,7 @@ func TestTranscoder_BufferTooLargeFails(t *testing.T) {
 		},
 		{
 			name: "enveloping_writer",
-			expectation: func(t *testing.T, rsp http.ResponseWriter, req *http.Request) {
+			expectation: func(t *testing.T, rsp http.ResponseWriter, _ *http.Request) {
 				t.Helper()
 				rw, ok := rsp.(*responseWriter)
 				require.True(t, ok, "response writer should be *responseWriter")
@@ -241,7 +241,7 @@ func TestTranscoder_BufferTooLargeFails(t *testing.T) {
 		},
 		{
 			name: "transforming_reader",
-			expectation: func(t *testing.T, rw http.ResponseWriter, req *http.Request) {
+			expectation: func(t *testing.T, _ http.ResponseWriter, req *http.Request) {
 				t.Helper()
 				_, ok := req.Body.(*transformingReader)
 				assert.True(t, ok, "request body should be *transformingReader")
@@ -285,7 +285,7 @@ func TestTranscoder_BufferTooLargeFails(t *testing.T) {
 		},
 		{
 			name: "transforming_writer",
-			expectation: func(t *testing.T, rsp http.ResponseWriter, req *http.Request) {
+			expectation: func(t *testing.T, rsp http.ResponseWriter, _ *http.Request) {
 				t.Helper()
 				rw, ok := rsp.(*responseWriter)
 				require.True(t, ok, "response writer should be *responseWriter")
@@ -431,7 +431,7 @@ func TestTranscoder_BufferTooLargeFails(t *testing.T) {
 		},
 		{
 			name: "error_writer",
-			expectation: func(t *testing.T, rsp http.ResponseWriter, req *http.Request) {
+			expectation: func(t *testing.T, rsp http.ResponseWriter, _ *http.Request) {
 				t.Helper()
 				rw, ok := rsp.(*responseWriter)
 				require.True(t, ok, "response writer should be *responseWriter")
@@ -480,7 +480,7 @@ func TestTranscoder_BufferTooLargeFails(t *testing.T) {
 		{
 			name:          "per_svc_options",
 			optsOnService: true,
-			makeMux: func(req *testRequest, svcs []*Service) (http.Handler, error) {
+			makeMux: func(_ *testRequest, svcs []*Service) (http.Handler, error) {
 				// svcs already have options defined on them
 				return NewTranscoder(svcs, WithDefaultServiceOptions(WithMaxMessageBufferBytes(1024)))
 			},
@@ -1609,7 +1609,7 @@ func checkStageRead(t *testing.T, msg *message, compressed bool) {
 func checkStageDecoded(t *testing.T, msg *message) {
 	t.Helper()
 	require.Equal(t, stageDecoded, msg.stage)
-	require.Equal(t, testDataString, msg.msg.(*wrapperspb.StringValue).Value)
+	require.Equal(t, testDataString, msg.msg.(*wrapperspb.StringValue).GetValue())
 	// Should not be possible to go backwards.
 	require.Error(t, msg.advanceToStage(nil, stageRead))
 	require.Error(t, msg.advanceToStage(nil, stageEmpty))
@@ -1647,7 +1647,7 @@ func (f *fakeCodec) Name() string {
 
 func (f *fakeCodec) MarshalAppend(b []byte, msg proto.Message) ([]byte, error) {
 	f.marshalCalls++
-	val := msg.(*wrapperspb.StringValue).Value
+	val := msg.(*wrapperspb.StringValue).GetValue()
 	return append(b, ([]byte)(val)...), nil
 }
 

--- a/vanguard_rpcxrest_test.go
+++ b/vanguard_rpcxrest_test.go
@@ -432,7 +432,7 @@ func TestMux_RPCxREST(t *testing.T) {
 					if req.output.wantErr != nil {
 						assert.Equal(t, req.output.wantErr.Code(), connect.CodeOf(err))
 					} else {
-						assert.NoError(t, err)
+						require.NoError(t, err)
 					}
 					assert.Subset(t, header, req.output.header)
 					assert.Subset(t, trailer, req.output.trailer)

--- a/vanguard_test.go
+++ b/vanguard_test.go
@@ -60,7 +60,7 @@ func TestRuleSelector(t *testing.T) {
 			Get: "/healthz",
 		},
 	}))
-	assert.ErrorContains(t, err, "rule \"grpc.health.v1.Health.Check\" does not match any methods")
+	assert.ErrorContains(t, err, "rule \"grpc.health.v1.Health.Check\" does not match any methods") //nolint:testifylint
 
 	_, err = NewTranscoder([]*Service{svc}, WithRules(&annotations.HttpRule{
 		Selector: "invalid.*.Get",
@@ -68,7 +68,7 @@ func TestRuleSelector(t *testing.T) {
 			Get: "/v1/*",
 		},
 	}))
-	assert.ErrorContains(t, err, "wildcard selector \"invalid.*.Get\" must be at the end")
+	assert.ErrorContains(t, err, "wildcard selector \"invalid.*.Get\" must be at the end") //nolint:testifylint
 
 	_, err = NewTranscoder([]*Service{svc}, WithRules(&annotations.HttpRule{
 		Selector: "grpc.health.v1.Health.*",
@@ -76,14 +76,14 @@ func TestRuleSelector(t *testing.T) {
 			Get: "/healthz",
 		},
 	}))
-	assert.ErrorContains(t, err, "rule \"grpc.health.v1.Health.*\" does not match any methods")
+	assert.ErrorContains(t, err, "rule \"grpc.health.v1.Health.*\" does not match any methods") //nolint:testifylint
 
 	_, err = NewTranscoder([]*Service{svc}, WithRules(&annotations.HttpRule{
 		Pattern: &annotations.HttpRule_Get{
 			Get: "/v1/*",
 		},
 	}))
-	assert.ErrorContains(t, err, "rule missing selector")
+	assert.ErrorContains(t, err, "rule missing selector") //nolint:testifylint
 
 	handler, err := NewTranscoder(
 		[]*Service{svc},
@@ -158,14 +158,14 @@ type testMsg struct {
 
 func (o *testMsg) getIn() (*testMsgIn, error) {
 	if o == nil || o.in == nil {
-		return nil, fmt.Errorf("missing input message")
+		return nil, errors.New("missing input message")
 	}
 	return o.in, nil
 }
 
 func (o *testMsg) getOut() (*testMsgOut, error) {
 	if o == nil || o.out == nil {
-		return nil, fmt.Errorf("missing output message")
+		return nil, errors.New("missing output message")
 	}
 	return o.out, nil
 }
@@ -240,7 +240,7 @@ func (s *ttStream) await(t *testing.T, expectServerDone bool) (serverInvoked boo
 	case <-s.done:
 		return true, s.result
 	case <-time.After(3 * time.Second):
-		return true, fmt.Errorf("timeout: interceptor still did not finish after 3 seconds")
+		return true, errors.New("timeout: interceptor still did not finish after 3 seconds")
 	}
 }
 
@@ -428,7 +428,7 @@ func (i *testInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc
 					}
 				}
 			default:
-				return fmt.Errorf("expected message")
+				return errors.New("expected message")
 			}
 		}
 		for key, vals := range stream.rspTrailer {
@@ -484,7 +484,7 @@ func (i *testInterceptor) restUnaryHandler(
 			} else {
 				codecName := codecNames[contentType]
 				if !assert.Equal(stream.T, codec.Name(), codecName, "codec didn't match") {
-					return fmt.Errorf("codec didn't match")
+					return errors.New("codec didn't match")
 				}
 				if err := codec.Unmarshal(body, got); err != nil {
 					return err
@@ -512,9 +512,9 @@ func (i *testInterceptor) restUnaryHandler(
 		rsp.Header().Set("Content-Encoding", "identity")
 		if restIsHTTPBody(out.msg.ProtoReflect().Descriptor(), nil) { //nolint:nestif
 			msg, _ := out.msg.(*httpbody.HttpBody)
-			rsp.Header().Set("Content-Type", msg.ContentType)
-			_, err = rsp.Write(msg.Data)
-			assert.NoError(stream.T, err, "failed to write response")
+			rsp.Header().Set("Content-Type", msg.GetContentType())
+			_, err = rsp.Write(msg.GetData())
+			require.NoError(stream.T, err, "failed to write response")
 		} else {
 			body, err = codec.MarshalAppend(nil, out.msg)
 			if err != nil {
@@ -530,7 +530,7 @@ func (i *testInterceptor) restUnaryHandler(
 				body = dst.Bytes()
 			}
 			_, err = rsp.Write(body)
-			assert.NoError(stream.T, err, "failed to write response")
+			require.NoError(stream.T, err, "failed to write response")
 		}
 
 		// Write trailers.
@@ -824,23 +824,23 @@ func protocolAssertMiddleware(
 		switch protocol {
 		case ProtocolGRPC:
 			wantHdr = map[string][]string{
-				"Content-Type":  {fmt.Sprintf("application/grpc+%s", codec)},
+				"Content-Type":  {"application/grpc+" + codec},
 				"Grpc-Encoding": allowedCompression,
 			}
 		case ProtocolGRPCWeb:
 			wantHdr = map[string][]string{
-				"Content-Type":  {fmt.Sprintf("application/grpc-web+%s", codec)},
+				"Content-Type":  {"application/grpc-web+" + codec},
 				"Grpc-Encoding": allowedCompression,
 			}
 		case ProtocolConnect:
 			if strings.HasPrefix(req.Header.Get("Content-Type"), "application/connect") {
 				wantHdr = map[string][]string{
-					"Content-Type":             {fmt.Sprintf("application/connect+%s", codec)},
+					"Content-Type":             {"application/connect+" + codec},
 					"Connect-Content-Encoding": allowedCompression,
 				}
 			} else if req.Method == http.MethodPost {
 				wantHdr = map[string][]string{
-					"Content-Type":     {fmt.Sprintf("application/%s", codec)},
+					"Content-Type":     {"application/" + codec},
 					"Content-Encoding": allowedCompression,
 				}
 			}
@@ -915,15 +915,15 @@ func runRPCTestCase[Client any](
 		receivedErr = stream.err
 	}
 	if receivedErr == nil {
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	} else {
-		assert.Equal(t, receivedErr.Code(), connect.CodeOf(err))
+		require.Equal(t, receivedErr.Code(), connect.CodeOf(err))
 	}
 	// Also check the error observed by the server.
 	if expectedErr == nil {
-		assert.NoError(t, serverErr)
+		require.NoError(t, serverErr)
 	} else if serverInvoked {
-		assert.Error(t, serverErr)
+		require.Error(t, serverErr)
 		if expectServerCancel && connect.CodeOf(serverErr) != connect.CodeOf(expectedErr) {
 			// We expect the server to either have seen the same error or it later
 			// observed a cancel error (since the middleware cancels the request

--- a/vanguardgrpc/vanguardgrpc_examples_test.go
+++ b/vanguardgrpc/vanguardgrpc_examples_test.go
@@ -75,7 +75,7 @@ func ExampleNewTranscoder_connectToGRPC() {
 		log.Println("error:", err)
 		return
 	}
-	log.Println(rsp.Msg.Title)
+	log.Println(rsp.Msg.GetTitle())
 	// Output: Do Androids Dream of Electric Sheep?
 }
 
@@ -85,8 +85,8 @@ type libraryRPC struct {
 
 func (s *libraryRPC) GetBook(_ context.Context, req *testv1.GetBookRequest) (*testv1.Book, error) {
 	return &testv1.Book{
-		Name:        req.Name,
-		Parent:      strings.Join(strings.Split(req.Name, "/")[:2], "/"),
+		Name:        req.GetName(),
+		Parent:      strings.Join(strings.Split(req.GetName(), "/")[:2], "/"),
 		CreateTime:  timestamppb.New(time.Date(1968, 1, 1, 0, 0, 0, 0, time.UTC)),
 		Title:       "Do Androids Dream of Electric Sheep?",
 		Author:      "Philip K. Dick",
@@ -98,10 +98,10 @@ func (s *libraryRPC) GetBook(_ context.Context, req *testv1.GetBookRequest) (*te
 }
 
 func (s *libraryRPC) CreateBook(_ context.Context, req *testv1.CreateBookRequest) (*testv1.Book, error) {
-	book := req.Book
+	book := req.GetBook()
 	return &testv1.Book{
-		Name:        strings.Join([]string{req.Parent, "books", req.BookId}, "/"),
-		Parent:      req.Parent,
+		Name:        strings.Join([]string{req.GetParent(), "books", req.GetBookId()}, "/"),
+		Parent:      req.GetParent(),
 		CreateTime:  timestamppb.New(time.Date(1968, 1, 1, 0, 0, 0, 0, time.UTC)),
 		Title:       book.GetTitle(),
 		Author:      book.GetAuthor(),


### PR DESCRIPTION
Increases the min go version to v1.20 and the current to v1.22. Also bumps the golinter to v1.56.2 and fixes the issues found.