### PR TITLE
Support JSON name query parameters

### DIFF
--- a/params.go
+++ b/params.go
@@ -75,19 +75,18 @@ func setParameter(msg protoreflect.Message, fields []protoreflect.FieldDescripto
 	data := []byte(param)
 	value, err := unmarshalFieldValue(leaf, field, data)
 	if err != nil {
+		fieldName := resolveFieldDescriptorsToPath(fields, false)
 		if jsonErr := (*json.UnmarshalTypeError)(nil); errors.As(err, &jsonErr) ||
 			// protojson errors are not exported, check the error string.
 			strings.HasPrefix(err.Error(), "proto") {
 			return connect.NewError(connect.CodeInvalidArgument,
 				fmt.Errorf("invalid parameter %q value for type %q: %s",
-					resolveFieldDescriptorsToPath(fields), field.Kind(), data,
+					fieldName, field.Kind(), data,
 				),
 			)
 		}
 		return connect.NewError(connect.CodeInvalidArgument,
-			fmt.Errorf("invalid parameter %q %w",
-				resolveFieldDescriptorsToPath(fields), err,
-			),
+			fmt.Errorf("invalid parameter %q %w", fieldName, err),
 		)
 	}
 

--- a/params.go
+++ b/params.go
@@ -75,18 +75,20 @@ func setParameter(msg protoreflect.Message, fields []protoreflect.FieldDescripto
 	data := []byte(param)
 	value, err := unmarshalFieldValue(leaf, field, data)
 	if err != nil {
-		fieldName := resolveFieldDescriptorsToPath(fields, false)
+		// Resolve the field path for the error message in proto format.
+		// The JSON format is not used for consistency with other errors.
+		fieldPath := resolveFieldDescriptorsToPath(fields, false)
 		if jsonErr := (*json.UnmarshalTypeError)(nil); errors.As(err, &jsonErr) ||
 			// protojson errors are not exported, check the error string.
 			strings.HasPrefix(err.Error(), "proto") {
 			return connect.NewError(connect.CodeInvalidArgument,
 				fmt.Errorf("invalid parameter %q value for type %q: %s",
-					fieldName, field.Kind(), data,
+					fieldPath, field.Kind(), data,
 				),
 			)
 		}
 		return connect.NewError(connect.CodeInvalidArgument,
-			fmt.Errorf("invalid parameter %q %w", fieldName, err),
+			fmt.Errorf("invalid parameter %q %w", fieldPath, err),
 		)
 	}
 

--- a/params_test.go
+++ b/params_test.go
@@ -62,7 +62,7 @@ func TestIsParameter(t *testing.T) {
 		testCase := testCase
 		t.Run(testCase.fieldPath, func(t *testing.T) {
 			t.Parallel()
-			fields, err := resolvePathToFieldDescriptors(desc, testCase.fieldPath, restFieldGetter)
+			fields, err := resolvePathToFieldDescriptors(desc, testCase.fieldPath, true)
 			require.NoError(t, err)
 			field := fields[len(fields)-1]
 			assert.Equal(t, testCase.isParam, isParameterType(field))
@@ -395,7 +395,7 @@ func TestSetParameter(t *testing.T) {
 			t.Parallel()
 
 			desc := testCase.want.ProtoReflect().Descriptor()
-			fields, err := resolvePathToFieldDescriptors(desc, testCase.fields, restFieldGetter)
+			fields, err := resolvePathToFieldDescriptors(desc, testCase.fields, true)
 			if err != nil {
 				assert.Equal(t, testCase.wantErr, err.Error())
 				return
@@ -695,7 +695,7 @@ func TestGetParameter(t *testing.T) {
 			t.Parallel()
 
 			desc := testCase.msg.ProtoReflect().Descriptor()
-			fields, err := resolvePathToFieldDescriptors(desc, testCase.fields, restFieldGetter)
+			fields, err := resolvePathToFieldDescriptors(desc, testCase.fields, true)
 			if err != nil {
 				assert.Equal(t, testCase.wantErr, err.Error())
 				return

--- a/params_test.go
+++ b/params_test.go
@@ -62,7 +62,7 @@ func TestIsParameter(t *testing.T) {
 		testCase := testCase
 		t.Run(testCase.fieldPath, func(t *testing.T) {
 			t.Parallel()
-			fields, err := resolvePathToDescriptors(desc, testCase.fieldPath)
+			fields, err := resolvePathToFieldDescriptors(desc, testCase.fieldPath, restFieldGetter)
 			require.NoError(t, err)
 			field := fields[len(fields)-1]
 			assert.Equal(t, testCase.isParam, isParameterType(field))
@@ -395,7 +395,7 @@ func TestSetParameter(t *testing.T) {
 			t.Parallel()
 
 			desc := testCase.want.ProtoReflect().Descriptor()
-			fields, err := resolvePathToDescriptors(desc, testCase.fields)
+			fields, err := resolvePathToFieldDescriptors(desc, testCase.fields, restFieldGetter)
 			if err != nil {
 				assert.Equal(t, testCase.wantErr, err.Error())
 				return
@@ -695,7 +695,7 @@ func TestGetParameter(t *testing.T) {
 			t.Parallel()
 
 			desc := testCase.msg.ProtoReflect().Descriptor()
-			fields, err := resolvePathToDescriptors(desc, testCase.fields)
+			fields, err := resolvePathToFieldDescriptors(desc, testCase.fields, restFieldGetter)
 			if err != nil {
 				assert.Equal(t, testCase.wantErr, err.Error())
 				return

--- a/protocol_http.go
+++ b/protocol_http.go
@@ -237,6 +237,8 @@ func httpEncodePathValues(input protoreflect.Message, target *routeTarget) (
 	fieldRanger = func(field protoreflect.FieldDescriptor, value protoreflect.Value) bool {
 		fields = append(fields, field)
 		defer func() { fields = fields[:len(fields)-1] }() // pop
+		// The field path is resolved to the proto format for lookups,
+		// but the query values are encoded in their JSON representation.
 		fieldPath := resolveFieldDescriptorsToPath(fields, false)
 		fieldIndex := fieldPathCounts[fieldPath]
 

--- a/protocol_http.go
+++ b/protocol_http.go
@@ -237,7 +237,7 @@ func httpEncodePathValues(input protoreflect.Message, target *routeTarget) (
 	fieldRanger = func(field protoreflect.FieldDescriptor, value protoreflect.Value) bool {
 		fields = append(fields, field)
 		defer func() { fields = fields[:len(fields)-1] }() // pop
-		fieldPath := resolveFieldDescriptorsToPath(fields)
+		fieldPath := resolveFieldDescriptorsToPath(fields, false)
 		fieldIndex := fieldPathCounts[fieldPath]
 
 		switch {
@@ -271,7 +271,11 @@ func httpEncodePathValues(input protoreflect.Message, target *routeTarget) (
 					fieldError = err
 					return false
 				}
-				query.Add(fieldPath, string(encoded))
+				query.Add(
+					// Query values are encoded in their JSON representation.
+					resolveFieldDescriptorsToPath(fields, true),
+					string(encoded),
+				)
 				fieldIndex++
 			}
 		case fieldIndex == 0:
@@ -280,7 +284,11 @@ func httpEncodePathValues(input protoreflect.Message, target *routeTarget) (
 				fieldError = err
 				return false
 			}
-			query.Add(fieldPath, string(encoded))
+			query.Add(
+				// Query values are encoded in their JSON representation.
+				resolveFieldDescriptorsToPath(fields, true),
+				string(encoded),
+			)
 			fieldIndex++
 		}
 

--- a/protocol_rest.go
+++ b/protocol_rest.go
@@ -160,7 +160,9 @@ func (r restClientProtocol) prepareUnmarshalledRequest(op *operation, src []byte
 	}
 	// And finally from the query string:
 	for fieldPath, values := range op.queryValues() {
-		fields, err := resolvePathToDescriptors(msg.Descriptor(), fieldPath)
+		fields, err := resolvePathToFieldDescriptors(
+			msg.Descriptor(), fieldPath, restFieldGetter,
+		)
 		if err != nil {
 			return err
 		}
@@ -439,6 +441,15 @@ func restIsHTTPBody(msg protoreflect.MessageDescriptor, bodyPath []protoreflect.
 		msg = field.Message()
 	}
 	return msg != nil && msg.FullName() == "google.api.HttpBody"
+}
+
+// restFieldGetter returns a field descriptor by name or JSON name.
+func restFieldGetter(fds protoreflect.FieldDescriptors, name protoreflect.Name) protoreflect.FieldDescriptor {
+	fd := fds.ByName(name)
+	if fd == nil {
+		fd = fds.ByJSONName(string(name))
+	}
+	return fd
 }
 
 type accessor func(protoreflect.Message, protoreflect.FieldDescriptor) protoreflect.Value

--- a/protocol_rest.go
+++ b/protocol_rest.go
@@ -161,7 +161,7 @@ func (r restClientProtocol) prepareUnmarshalledRequest(op *operation, src []byte
 	// And finally from the query string:
 	for fieldPath, values := range op.queryValues() {
 		fields, err := resolvePathToFieldDescriptors(
-			msg.Descriptor(), fieldPath, restFieldGetter,
+			msg.Descriptor(), fieldPath, true,
 		)
 		if err != nil {
 			return err
@@ -441,15 +441,6 @@ func restIsHTTPBody(msg protoreflect.MessageDescriptor, bodyPath []protoreflect.
 		msg = field.Message()
 	}
 	return msg != nil && msg.FullName() == "google.api.HttpBody"
-}
-
-// restFieldGetter returns a field descriptor by name or JSON name.
-func restFieldGetter(fds protoreflect.FieldDescriptors, name protoreflect.Name) protoreflect.FieldDescriptor {
-	fd := fds.ByName(name)
-	if fd == nil {
-		fd = fds.ByJSONName(string(name))
-	}
-	return fd
 }
 
 type accessor func(protoreflect.Message, protoreflect.FieldDescriptor) protoreflect.Value

--- a/router.go
+++ b/router.go
@@ -351,6 +351,8 @@ func computeVarValues(path []string, target *routeTarget) ([]routeTargetVarMatch
 
 // resolvePathToFieldDescriptors translates the given path string, in the form of
 // "ident.ident.ident", into a path of FieldDescriptors, relative to the given msg.
+// If fromJSON is true, the JSON name of the field is used first, falling back to
+// the proto name.
 func resolvePathToFieldDescriptors(
 	msg protoreflect.MessageDescriptor, path string, fromJSON bool,
 ) ([]protoreflect.FieldDescriptor, error) {
@@ -396,7 +398,7 @@ func resolvePathToFieldDescriptors(
 }
 
 // resolveFieldDescriptorsToPath translates the given path of FieldDescriptors into a string
-// of the form "ident.ident.ident".
+// of the form "ident.ident.ident". If toJSON is true, the JSON name of the field is used.
 func resolveFieldDescriptorsToPath(fields []protoreflect.FieldDescriptor, toJSON bool) string {
 	if len(fields) == 0 {
 		return ""

--- a/router.go
+++ b/router.go
@@ -216,29 +216,49 @@ func makeTarget(
 	segments pathSegments,
 	variables []pathVariable,
 ) (*routeTarget, error) {
-	requestBodyFields, err := resolvePathToDescriptors(config.descriptor.Input(), requestBody)
-	if err != nil {
-		return nil, err
-	}
-	if len(requestBodyFields) > 1 {
-		return nil, fmt.Errorf(
-			"unexpected request body path %q: must be a single field",
-			requestBody,
+	var requestBodyFields []protoreflect.FieldDescriptor
+	if requestBody == "*" {
+		// non-nil, empty slice means use the whole thing
+		requestBodyFields = []protoreflect.FieldDescriptor{}
+	} else if requestBody != "" {
+		var err error
+		requestBodyFields, err = resolvePathToFieldDescriptors(
+			config.descriptor.Input(), requestBody, protoreflect.FieldDescriptors.ByName,
 		)
+		if err != nil {
+			return nil, err
+		}
+		if len(requestBodyFields) > 1 {
+			return nil, fmt.Errorf(
+				"unexpected request body path %q: must be a single field",
+				requestBody,
+			)
+		}
 	}
-	responseBodyFields, err := resolvePathToDescriptors(config.descriptor.Output(), responseBody)
-	if err != nil {
-		return nil, err
-	}
-	if len(responseBodyFields) > 1 {
-		return nil, fmt.Errorf(
-			"unexpected response body path %q: must be a single field",
-			requestBody,
+	var responseBodyFields []protoreflect.FieldDescriptor
+	if responseBody == "*" {
+		// non-nil, empty slice means use the whole thing
+		responseBodyFields = []protoreflect.FieldDescriptor{}
+	} else if responseBody != "" {
+		var err error
+		responseBodyFields, err = resolvePathToFieldDescriptors(
+			config.descriptor.Output(), responseBody, protoreflect.FieldDescriptors.ByName,
 		)
+		if err != nil {
+			return nil, err
+		}
+		if len(responseBodyFields) > 1 {
+			return nil, fmt.Errorf(
+				"unexpected response body path %q: must be a single field",
+				requestBody,
+			)
+		}
 	}
 	routeTargetVars := make([]routeTargetVar, len(variables))
 	for i, variable := range variables {
-		fields, err := resolvePathToDescriptors(config.descriptor.Input(), variable.fieldPath)
+		fields, err := resolvePathToFieldDescriptors(
+			config.descriptor.Input(), variable.fieldPath, protoreflect.FieldDescriptors.ByName,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -329,27 +349,32 @@ func computeVarValues(path []string, target *routeTarget) ([]routeTargetVarMatch
 	return vars, nil
 }
 
-// resolvePathToDescriptors translates the given path string, in the form of "ident.ident.ident",
-// into a path of FieldDescriptors, relative to the given msg.
-func resolvePathToDescriptors(msg protoreflect.MessageDescriptor, path string) ([]protoreflect.FieldDescriptor, error) {
+// resolvePathToFieldDescriptors translates the given path string, in the form of
+// "ident.ident.ident", into a path of FieldDescriptors, relative to the given msg.
+func resolvePathToFieldDescriptors(
+	msg protoreflect.MessageDescriptor,
+	path string,
+	getter func(protoreflect.FieldDescriptors, protoreflect.Name) protoreflect.FieldDescriptor,
+) ([]protoreflect.FieldDescriptor, error) {
 	if path == "" {
-		return nil, nil
-	}
-	if path == "*" {
-		// non-nil, empty slice means use the whole thing
-		return []protoreflect.FieldDescriptor{}, nil
+		return nil, fmt.Errorf("empty field path")
 	}
 	fields := msg.Fields()
-	parts := strings.Split(path, ".")
-	result := make([]protoreflect.FieldDescriptor, len(parts))
-	for i, part := range parts {
-		field := fields.ByName(protoreflect.Name(part))
+	result := make([]protoreflect.FieldDescriptor, strings.Count(path, ".")+1)
+	for i, remaining := 0, path; remaining != ""; i++ {
+		part := remaining
+		if i := strings.IndexByte(remaining, '.'); i >= 0 {
+			part, remaining = remaining[:i], remaining[i+1:]
+		} else {
+			remaining = ""
+		}
+		field := getter(fields, protoreflect.Name(part))
 		if field == nil {
 			return nil, fmt.Errorf("in field path %q: element %q does not correspond to any field of type %s",
 				path, part, msg.FullName())
 		}
 		result[i] = field
-		if i == len(parts)-1 {
+		if remaining == "" {
 			break
 		}
 		if field.Cardinality() == protoreflect.Repeated {
@@ -372,11 +397,14 @@ func resolveFieldDescriptorsToPath(fields []protoreflect.FieldDescriptor) string
 	if len(fields) == 0 {
 		return ""
 	}
-	parts := make([]string, len(fields))
+	sb := strings.Builder{}
 	for i, field := range fields {
-		parts[i] = string(field.Name())
+		if i > 0 {
+			sb.WriteByte('.')
+		}
+		_, _ = sb.WriteString(string(field.Name()))
 	}
-	return strings.Join(parts, ".")
+	return sb.String()
 }
 
 type alreadyExistsError struct {

--- a/vanguard_restxrpc_test.go
+++ b/vanguard_restxrpc_test.go
@@ -281,51 +281,9 @@ func TestMux_RESTxRPC(t *testing.T) {
 			method: http.MethodPost,
 			path:   "/v1/shelves/1/books",
 			values: url.Values{
-				"book_id":    []string{"1"},
+				// Fields by JSON name or proto name are supported.
+				"bookId":     []string{"1"},
 				"request_id": []string{"2"},
-			},
-			body: &testv1.Book{
-				Title:  "The Art of Computer Programming",
-				Author: "Donald E. Knuth",
-			},
-		},
-		stream: testStream{
-			method: testv1connect.LibraryServiceCreateBookProcedure,
-			msgs: []testMsg{
-				{in: &testMsgIn{
-					msg: &testv1.CreateBookRequest{
-						Parent:    "shelves/1",
-						BookId:    "1",
-						RequestId: "2",
-						Book: &testv1.Book{
-							Title:  "The Art of Computer Programming",
-							Author: "Donald E. Knuth",
-						},
-					},
-				}},
-				{out: &testMsgOut{
-					msg: &testv1.Book{
-						Title:  "The Art of Computer Programming",
-						Author: "Donald E. Knuth",
-					},
-				}},
-			},
-		},
-		output: output{
-			code: http.StatusOK,
-			body: &testv1.Book{
-				Title:  "The Art of Computer Programming",
-				Author: "Donald E. Knuth",
-			},
-		},
-	}, {
-		name: "CreateBook-JSONQueryParams",
-		input: input{
-			method: http.MethodPost,
-			path:   "/v1/shelves/1/books",
-			values: url.Values{
-				"bookId":    []string{"1"},
-				"requestId": []string{"2"},
 			},
 			body: &testv1.Book{
 				Title:  "The Art of Computer Programming",

--- a/vanguard_restxrpc_test.go
+++ b/vanguard_restxrpc_test.go
@@ -319,6 +319,49 @@ func TestMux_RESTxRPC(t *testing.T) {
 			},
 		},
 	}, {
+		name: "CreateBook-JSONQueryParams",
+		input: input{
+			method: http.MethodPost,
+			path:   "/v1/shelves/1/books",
+			values: url.Values{
+				"bookId":    []string{"1"},
+				"requestId": []string{"2"},
+			},
+			body: &testv1.Book{
+				Title:  "The Art of Computer Programming",
+				Author: "Donald E. Knuth",
+			},
+		},
+		stream: testStream{
+			method: testv1connect.LibraryServiceCreateBookProcedure,
+			msgs: []testMsg{
+				{in: &testMsgIn{
+					msg: &testv1.CreateBookRequest{
+						Parent:    "shelves/1",
+						BookId:    "1",
+						RequestId: "2",
+						Book: &testv1.Book{
+							Title:  "The Art of Computer Programming",
+							Author: "Donald E. Knuth",
+						},
+					},
+				}},
+				{out: &testMsgOut{
+					msg: &testv1.Book{
+						Title:  "The Art of Computer Programming",
+						Author: "Donald E. Knuth",
+					},
+				}},
+			},
+		},
+		output: output{
+			code: http.StatusOK,
+			body: &testv1.Book{
+				Title:  "The Art of Computer Programming",
+				Author: "Donald E. Knuth",
+			},
+		},
+	}, {
 		name: "MoveBooks",
 		input: input{
 			method: http.MethodPost,

--- a/vanguard_rpcxrest_test.go
+++ b/vanguard_rpcxrest_test.go
@@ -228,7 +228,7 @@ func TestMux_RPCxREST(t *testing.T) {
 			return outputFromUnary(ctx, clients.libClient.CreateBook, hdr, msgs)
 		},
 		stream: testStream{
-			method: "/v1/shelves/1/books?book_id=1&request_id=2",
+			method: "/v1/shelves/1/books?bookId=1&requestId=2",
 			msgs: []testMsg{
 				{in: &testMsgIn{
 					msg: &testv1.Book{


### PR DESCRIPTION
Allows for query parameters to be specified by the fields JSON name. This is supported by other implementations. Only enable JSON names for query parameters and not within rule descriptors. By default encoding to REST streams will now set query params as the JSON representation. This is more consistent with the JSON body representation of the fields.

Fixes #131