### PR TITLE
Fix panic on invalid field path error

### DIFF
--- a/router.go
+++ b/router.go
@@ -387,12 +387,12 @@ func resolvePathToFieldDescriptors(
 			return nil, fmt.Errorf("in field path %q: field %q of type %s should not be a list or map",
 				path, part, msg.FullName())
 		}
-		msg = field.Message()
-		if msg == nil {
+		childMsg := field.Message()
+		if childMsg == nil {
 			return nil, fmt.Errorf("in field path %q: field %q of type %s should be a message but is instead %s",
 				path, part, msg.FullName(), field.Kind())
 		}
-		fields = msg.Fields()
+		msg, fields = childMsg, childMsg.Fields()
 	}
 	return result, nil
 }


### PR DESCRIPTION
Avoid nil pointer dereference on an invalid child message type when resolving field paths. Var `msg` is updated and on nil and error reported but now references the nil pointer `msg.FullName()` in the error message. Updated to refer to the parent message type.