### PR TITLE
Fix errors in writer loops and omit cancelation after trailers written

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,3 @@
-run:
-  skip-dirs-use-default: false
 linters-settings:
   errcheck:
     check-type-assertions: true
@@ -52,6 +50,7 @@ linters:
     - wrapcheck         # don't _always_ need to wrap errors
     - wsl               # generous whitespace violates house style
 issues:
+  exclude-dirs-use-default: false
   exclude:
     # Don't ban use of fmt.Errorf to create new errors, but the remaining
     # checks from err113 are useful.

--- a/regress_test.go
+++ b/regress_test.go
@@ -1,0 +1,135 @@
+// Copyright 2023-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vanguard_test
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"testing"
+
+	"buf.build/gen/go/connectrpc/eliza/connectrpc/go/connectrpc/eliza/v1/elizav1connect"
+	elizav1 "buf.build/gen/go/connectrpc/eliza/protocolbuffers/go/connectrpc/eliza/v1"
+	"connectrpc.com/connect"
+	"connectrpc.com/vanguard"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+)
+
+// Reproducer test case provided in https://github.com/connectrpc/vanguard-go/issues/148
+func TestIssue148(t *testing.T) {
+	t.Parallel()
+
+	// GRPC-web server (process 1)
+	mux := http.NewServeMux()
+	mux.Handle(elizav1connect.NewElizaServiceHandler(&handler{t: t}))
+	grpcwebServer := httptest.NewUnstartedServer(
+		h2c.NewHandler(mux, &http2.Server{}),
+	)
+	grpcwebServer.EnableHTTP2 = true
+	grpcwebServer.Start()
+	t.Cleanup(grpcwebServer.Close)
+
+	// Vanguard based proxy (process 2)
+	webURL, err := url.Parse(grpcwebServer.URL)
+	require.NoError(t, err)
+	proxy := httputil.NewSingleHostReverseProxy(webURL)
+	proxy.FlushInterval = -1 // shouldn't be necessary
+	schema, err := protoregistry.GlobalFiles.FindDescriptorByName("connectrpc.eliza.v1.ElizaService")
+	require.NoError(t, err)
+	transcoder, err := vanguard.NewTranscoder(
+		[]*vanguard.Service{vanguard.NewServiceWithSchema(schema.(protoreflect.ServiceDescriptor), proxy)},
+		vanguard.WithDefaultServiceOptions(
+			vanguard.WithTargetProtocols(vanguard.ProtocolGRPCWeb),
+			vanguard.WithTargetCodecs(vanguard.CodecProto),
+		),
+		vanguard.WithUnknownHandler(proxy),
+	)
+	require.NoError(t, err)
+	vanguardServer := httptest.NewUnstartedServer(
+		h2c.NewHandler(
+			transcoder,
+			&http2.Server{},
+		),
+	)
+	vanguardServer.EnableHTTP2 = true
+	vanguardServer.Start()
+	t.Cleanup(vanguardServer.Close)
+
+	clientCases := map[string][]connect.ClientOption{
+		"proto": {connect.WithGRPC()},
+		"json":  {connect.WithGRPC(), connect.WithProtoJSON()},
+	}
+	for caseName := range clientCases {
+		caseName := caseName
+		clientOpts := clientCases[caseName]
+		t.Run(caseName, func(t *testing.T) {
+			t.Parallel()
+
+			// grpc client using h2c (process 3)
+			h2cClient := &http.Client{
+				Transport: &http2.Transport{
+					AllowHTTP: true,
+					DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+						return (&net.Dialer{}).DialContext(ctx, network, addr)
+					},
+				},
+			}
+
+			client := elizav1connect.NewElizaServiceClient(h2cClient, vanguardServer.URL, clientOpts...)
+			unaryResp, err := client.Say(context.Background(), connect.NewRequest(&elizav1.SayRequest{Sentence: "foo"}))
+			require.NoError(t, err)
+			require.Equal(t, "echo foo", unaryResp.Msg.Sentence)
+
+			serverStream, err := client.Introduce(context.Background(), connect.NewRequest(&elizav1.IntroduceRequest{Name: "foo"}))
+			require.NoError(t, err)
+			var responses []string
+			for serverStream.Receive() {
+				responses = append(responses, serverStream.Msg().Sentence)
+			}
+			require.NoError(t, serverStream.Err())
+			require.Equal(t, []string{"hi", "hi again"}, responses)
+		})
+	}
+}
+
+type handler struct {
+	elizav1connect.UnimplementedElizaServiceHandler
+	t testing.TB
+}
+
+func (h *handler) Say(_ context.Context, req *connect.Request[elizav1.SayRequest]) (*connect.Response[elizav1.SayResponse], error) {
+	if req.Peer().Protocol != connect.ProtocolGRPCWeb {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("only accepts grpc-web, got %q", req.Peer().Protocol))
+	}
+	return connect.NewResponse(&elizav1.SayResponse{Sentence: "echo " + req.Msg.Sentence}), nil
+}
+
+func (h *handler) Introduce(_ context.Context, req *connect.Request[elizav1.IntroduceRequest], resp *connect.ServerStream[elizav1.IntroduceResponse]) error {
+	if req.Peer().Protocol != connect.ProtocolGRPCWeb {
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("only accepts grpc-web, got %q", req.Peer().Protocol))
+	}
+	_ = resp.Send(&elizav1.IntroduceResponse{Sentence: "hi"})
+	_ = resp.Send(&elizav1.IntroduceResponse{Sentence: "hi again"})
+	return nil
+}

--- a/transcoder.go
+++ b/transcoder.go
@@ -35,6 +35,10 @@ import (
 	"google.golang.org/protobuf/types/dynamicpb"
 )
 
+var (
+	errFinalDataAlreadyWritten = fmt.Errorf("final RPC response data already written: %w", context.Canceled)
+)
+
 // Transcoder is a Vanguard handler which acts like a router and a middleware. It transforms
 // all supported input protocols (Connect, gRPC, gRPC-Web, REST) into a protocol that the
 // service handlers support. It can do simple routing based on RPC method name, for simple
@@ -1222,8 +1226,7 @@ func (w *responseWriter) reportEnd(end *responseEnd) {
 	}
 	w.flusher.Flush()
 	// response is done
-	w.op.cancel()
-	w.err = context.Canceled
+	w.err = errFinalDataAlreadyWritten
 }
 
 func (w *responseWriter) flushHeaders() {
@@ -1311,7 +1314,7 @@ type envelopingWriter struct {
 	trailerIsCompressed bool
 }
 
-func (w *envelopingWriter) Write(data []byte) (int, error) {
+func (w *envelopingWriter) Write(data []byte) (n int, err error) {
 	w.maybeInit()
 	if w.err != nil {
 		return 0, w.err
@@ -1359,6 +1362,10 @@ func (w *envelopingWriter) Write(data []byte) (int, error) {
 			err := w.handleTrailer()
 			if err != nil {
 				return written, err
+			}
+			if len(data) == 0 {
+				// All done
+				return written, nil
 			}
 		} else {
 			// flush after each message and reset for next envelope
@@ -1527,7 +1534,7 @@ func (w *envelopingWriter) handleTrailer() error {
 	}
 	end.wasCompressed = w.trailerIsCompressed
 	w.rw.reportEnd(&end)
-	w.err = errors.New("final data already written")
+	w.err = errFinalDataAlreadyWritten
 	return nil
 }
 
@@ -1547,6 +1554,7 @@ type transformingWriter struct {
 	expectingBytes  int
 	writingEnvelope bool
 	latestEnvelope  envelope
+	trailerWritten  bool
 }
 
 func (w *transformingWriter) Write(data []byte) (n int, err error) {
@@ -1583,7 +1591,7 @@ func (w *transformingWriter) Write(data []byte) (n int, err error) {
 		w.buffer.Write(data[:remainingBytes])
 		written += remainingBytes
 		data = data[remainingBytes:]
-		if w.writingEnvelope {
+		if w.writingEnvelope { //nolint:nestif
 			var envBytes envelopeBytes
 			_, _ = w.buffer.Read(envBytes[:])
 			var err error
@@ -1606,6 +1614,10 @@ func (w *transformingWriter) Write(data []byte) (n int, err error) {
 			if err := w.flushMessage(); err != nil {
 				w.rw.reportError(err)
 				return written, err
+			}
+			if w.trailerWritten && len(data) == 0 {
+				// All done.
+				return written, nil
 			}
 			w.expectingBytes = envelopeLen
 			w.writingEnvelope = true
@@ -1651,7 +1663,8 @@ func (w *transformingWriter) flushMessage() error {
 		}
 		end.wasCompressed = w.latestEnvelope.compressed
 		w.rw.reportEnd(&end)
-		w.err = errors.New("final data already written")
+		w.err = errFinalDataAlreadyWritten
+		w.trailerWritten = true
 		return nil
 	}
 
@@ -1748,7 +1761,7 @@ type noResponseBodyWriter struct {
 }
 
 func (c noResponseBodyWriter) Write([]byte) (int, error) {
-	return 0, errors.New("final data already written")
+	return 0, errFinalDataAlreadyWritten
 }
 
 func (c noResponseBodyWriter) Close() error {

--- a/transcoder.go
+++ b/transcoder.go
@@ -1554,7 +1554,6 @@ type transformingWriter struct {
 	expectingBytes  int
 	writingEnvelope bool
 	latestEnvelope  envelope
-	trailerWritten  bool
 }
 
 func (w *transformingWriter) Write(data []byte) (n int, err error) {
@@ -1615,7 +1614,7 @@ func (w *transformingWriter) Write(data []byte) (n int, err error) {
 				w.rw.reportError(err)
 				return written, err
 			}
-			if w.trailerWritten && len(data) == 0 {
+			if w.latestEnvelope.trailer && len(data) == 0 {
 				// All done.
 				return written, nil
 			}
@@ -1664,7 +1663,6 @@ func (w *transformingWriter) flushMessage() error {
 		end.wasCompressed = w.latestEnvelope.compressed
 		w.rw.reportEnd(&end)
 		w.err = errFinalDataAlreadyWritten
-		w.trailerWritten = true
 		return nil
 	}
 


### PR DESCRIPTION
There was a logic bug in `envelopingWriter` and `transformingWriter` that could cause it to spuriously return a non-nil error after it had finished writing trailers for a response.

There was also an issue with `responseWriter.reportEnd`, which would cancel the operation context, which could then cause the handler to freak out. In particular, `httputil.ReverseProxy` could observe a context cancelation when trying to proxy the response bytes (even though all response bytes were copied and the cancellation was right after the final byte was written). The reverse proxy, when it encounters an error, will `panic(http.ErrAbortWrite)`, which then causes the HTTP/2 stream to be cancelled (if HTTP/2 is used) instead of a normal stream termination.

This adds the entirety of the repro test case in #148, almost verbatim, to tests in this repo.

Resolves #148.