### PR TITLE
Add support for gRPC-Web text encoding

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -46,6 +46,11 @@ const (
 	// streaming endpoints. However, bidirectional streams are only supported
 	// when combined with HTTP/2.
 	ProtocolGRPCWeb
+	// ProtocolGRPCWebText is a variant of ProtocolGRPCWeb that uses base64
+	// text encoding for the request and response bodies.
+	//
+	// This protocol is not supported on the server side.
+	ProtocolGRPCWebText
 	// ProtocolREST indicates the REST+JSON protocol. This protocol often
 	// requires non-trivial transformations between HTTP requests and responses
 	// and Protobuf request and response messages.
@@ -96,6 +101,8 @@ func (p Protocol) serverHandler(op *operation) serverProtocolHandler {
 		return grpcServerProtocol{}
 	case ProtocolGRPCWeb:
 		return grpcWebServerProtocol{}
+	case ProtocolGRPCWebText:
+		return nil // gRPC-Web Text is not supported on the server.
 	case ProtocolREST:
 		return restServerProtocol{}
 	default:

--- a/protocol_rest.go
+++ b/protocol_rest.go
@@ -437,6 +437,9 @@ func restHTTPBodyRequest(op *operation) bool {
 }
 
 func restHTTPBodyResponse(op *operation) bool {
+	if op.restTarget == nil {
+		return false
+	}
 	return restIsHTTPBody(op.methodConf.descriptor.Output(), op.restTarget.responseBodyFields)
 }
 

--- a/transcoder.go
+++ b/transcoder.go
@@ -312,6 +312,8 @@ func classifyRequest(req *http.Request) (clientProtocolHandler, url.Values) {
 		return grpcClientProtocol{}, nil
 	case contentType == "application/grpc-web" || strings.HasPrefix(contentType, "application/grpc-web+"):
 		return grpcWebClientProtocol{}, nil
+	case contentType == "application/grpc-web-text" || strings.HasPrefix(contentType, "application/grpc-web-text+"):
+		return grpcWebTextClientProtocol{}, nil
 	case strings.HasPrefix(contentType, "application/"):
 		connectVersion := req.Header["Connect-Protocol-Version"]
 		if len(connectVersion) == 1 && connectVersion[0] == "1" {
@@ -2177,10 +2179,10 @@ func asFlusher(respWriter http.ResponseWriter) http.Flusher {
 	// we can't use that since it isn't available prior to Go 1.21.
 	for {
 		switch typedWriter := respWriter.(type) {
-		case http.Flusher:
-			return typedWriter
 		case errorFlusher:
 			return flusherNoError{f: typedWriter}
+		case http.Flusher:
+			return typedWriter
 		case interface{ Unwrap() http.ResponseWriter }:
 			respWriter = typedWriter.Unwrap()
 		default:


### PR DESCRIPTION
This adds support for gRPC-Web's text encoding to handle `application/grpc-web-text` content types. Only client support is added for now, for simplicity. Encoding of request and response body is handled to support text streams. Testing is added by mutating a gRPC-Web client to implement the text protocol.

Closes https://github.com/connectrpc/vanguard-go/issues/143