### PR TITLE
Upgrade min go 1.22 with tools

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.21.x, 1.22.x, 1.23.x]
+        go-version: [1.22.x, 1.23.x, 1.24.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -32,5 +32,5 @@ jobs:
         # conflicting guidance, run only on the most recent supported version.
         # For the same reason, only check generated code on the most recent
         # supported version.
-        if: matrix.go-version == '1.23.x'
+        if: matrix.go-version == '1.24.x'
         run: make checkgenerate && make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,12 +32,10 @@ linters:
   disable:
     - cyclop            # covered by gocyclo
     - depguard          # unnecessary for small libraries
-    - execinquery       # deprecated since golangci v1.58
     - funlen            # rely on code review to limit function length
     - gocognit          # dubious "cognitive overhead" quantification
     - gofumpt           # prefer standard gofmt
     - goimports         # rely on gci instead
-    - gomnd             # some unnamed constants are okay
     - inamedparam       # convention is not followed
     - ireturn           # "accept interfaces, return structs" isn't ironclad
     - lll               # don't want hard limits for line length
@@ -46,6 +44,7 @@ linters:
     - nlreturn          # generous whitespace violates house style
     - nonamedreturns    # named returns are fine; it's *bare* returns that are bad
     - protogetter       # too many false positives
+    - tenv              # replaced by usetesting
     - testpackage       # internal tests are fine
     - wrapcheck         # don't _always_ need to wrap errors
     - wsl               # generous whitespace violates house style

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ MAKEFLAGS += --no-print-directory
 BIN := .tmp/bin
 COPYRIGHT_YEARS := 2023-2025
 LICENSE_IGNORE := -e testdata/
-BUF_VERSION ?= 1.49.0
+BUF_VERSION ?= 1.50.1
 # Set to use a different compiler. For example, `GO=go1.18rc1 make test`.
 GO ?= go
 
@@ -91,4 +91,4 @@ $(BIN)/license-header: Makefile
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.1
+	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.7

--- a/codec_test.go
+++ b/codec_test.go
@@ -71,7 +71,6 @@ func TestJSONStabilize(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			result, err := jsonStabilize(([]byte)(testCase.input))
@@ -409,7 +408,7 @@ func TestJSONCodec_MarshalField(t *testing.T) {
 			target := msg.NewField(field)
 			listVal := target.List()
 			source := reflect.ValueOf(val)
-			for i := 0; i < source.Len(); i++ {
+			for i := range source.Len() {
 				listVal.Append(asSingularValue(source.Index(i).Interface()))
 			}
 			return target
@@ -464,9 +463,7 @@ func TestJSONCodec_MarshalField(t *testing.T) {
 		t.Run(marshalOpt.name, func(t *testing.T) {
 			t.Parallel()
 			for _, testCase := range testCases {
-				testCase := testCase
 				for _, fieldName := range testCase.fieldNames {
-					fieldName := fieldName
 					t.Run(fieldName, func(t *testing.T) {
 						t.Parallel()
 						msg := (&testv1.AllTypes{}).ProtoReflect()

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module connectrpc.com/vanguard
 
-go 1.21
+go 1.22
 
 require (
 	buf.build/gen/go/connectrpc/eliza/connectrpc/go v1.11.1-20230822171018-8b8b971d6fde.1

--- a/params.go
+++ b/params.go
@@ -67,8 +67,8 @@ func isWKTWithScalarJSONMapping(field protoreflect.FieldDescriptor) bool {
 func setParameter(msg protoreflect.Message, fields []protoreflect.FieldDescriptor, param string) error {
 	// Traverse the message to the last field.
 	leaf := msg
-	for i := 0; i < len(fields)-1; i++ {
-		leaf = leaf.Mutable(fields[i]).Message()
+	for _, field := range fields[:len(fields)-1] {
+		leaf = leaf.Mutable(field).Message()
 	}
 	field := fields[len(fields)-1]
 
@@ -255,8 +255,8 @@ func isNullValue(field protoreflect.FieldDescriptor) bool {
 func getParameter(msg protoreflect.Message, fields []protoreflect.FieldDescriptor, index int) (string, error) {
 	// Traverse the message to the last field.
 	leaf := msg
-	for i := 0; i < len(fields)-1; i++ {
-		leaf = leaf.Mutable(fields[i]).Message()
+	for _, field := range fields[:len(fields)-1] {
+		leaf = leaf.Mutable(field).Message()
 	}
 	field := fields[len(fields)-1]
 

--- a/params_test.go
+++ b/params_test.go
@@ -59,7 +59,6 @@ func TestIsParameter(t *testing.T) {
 		isParam:   false,
 	}}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.fieldPath, func(t *testing.T) {
 			t.Parallel()
 			fields, err := resolvePathToFieldDescriptors(desc, testCase.fieldPath, true)
@@ -401,7 +400,6 @@ func TestSetParameter(t *testing.T) {
 		wantErr: "unknown field in field path \"unknownField\": element \"unknownField\" does not correspond to any field of type vanguard.test.v1.ParameterValues",
 	}}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.fields+"="+testCase.value, func(t *testing.T) {
 			t.Parallel()
 
@@ -701,7 +699,6 @@ func TestGetParameter(t *testing.T) {
 		want: "2021-01-01T00:00:00Z",
 	}}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.fields+"="+testCase.want, func(t *testing.T) {
 			t.Parallel()
 

--- a/path_parser.go
+++ b/path_parser.go
@@ -295,7 +295,7 @@ func pathIsHexSlash(input string) bool {
 func pathEscape(input string, mode pathEncoding) string {
 	// Count the number of characters that possibly escaping.
 	hexCount := 0
-	for i := 0; i < len(input); i++ {
+	for i := range len(input) {
 		if pathShouldEscape(input[i], mode) {
 			hexCount++
 		}

--- a/path_parser_test.go
+++ b/path_parser_test.go
@@ -230,7 +230,6 @@ func TestPath_ParsePathTemplate(t *testing.T) {
 		},
 	}}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.tmpl, func(t *testing.T) {
 			t.Parallel()
 			segments, variables, err := parsePathTemplate(testCase.tmpl)
@@ -292,7 +291,6 @@ func TestPath_Escaping(t *testing.T) {
 		wantEscaped: "foo%2Fbar",
 	}}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.input, func(t *testing.T) {
 			t.Parallel()
 			dec, err := pathUnescape(testCase.input, testCase.mode)

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -513,18 +513,16 @@ func grpcExtractErrorFromTrailer(trailers http.Header) *connect.Error {
 		return nil
 	}
 
-	code64, err := strconv.ParseUint(codeHeader, 10 /* base */, 32 /* bitsize */)
+	code, err := strconv.ParseUint(codeHeader, 10 /* base */, 32 /* bitsize */)
 	if err != nil {
 		return connect.NewError(
 			connect.CodeInternal,
 			protocolError("invalid error code %q: %w", codeHeader, err),
 		)
 	}
-	if code64 == 0 {
+	if code == 0 {
 		return nil
 	}
-	code := uint32(code64)
-
 	if len(grpcDetails) == 0 {
 		message, err := grpcPercentDecode(grpcMsg)
 		if err != nil {

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/textproto"
 	"strconv"
@@ -185,7 +186,11 @@ func (g grpcWebClientProtocol) encodeEnd(op *operation, end *responseEnd, writer
 	defer op.bufferPool.Put(buffer)
 	_ = trailers.Write(buffer)
 	// TODO: Send envelope compressed if possible.
-	env := envelope{trailer: true, length: uint32(buffer.Len())}
+	length := len(buffer.Bytes())
+	if length > math.MaxUint32 {
+		return nil
+	}
+	env := envelope{trailer: true, length: uint32(length)}
 	envBytes := g.encodeEnvelope(env)
 	_, _ = writer.Write(envBytes[:])
 	_, _ = buffer.WriteTo(writer)
@@ -394,7 +399,7 @@ func grpcWriteEndToTrailers(respEnd *responseEnd, trailers http.Header) {
 
 func grpcStatusFromError(err *connect.Error) *status.Status {
 	stat := &status.Status{
-		Code:    int32(err.Code()),
+		Code:    int32(err.Code()), //nolint:gosec // No information loss.
 		Message: err.Message(),
 	}
 	if details := err.Details(); len(details) > 0 {
@@ -423,7 +428,7 @@ func grpcStatusFromError(err *connect.Error) *status.Status {
 //	https://datatracker.ietf.org/doc/html/rfc3986#section-2.1
 func grpcPercentEncode(msg string) string {
 	var hexCount int
-	for i := 0; i < len(msg); i++ {
+	for i := range len(msg) {
 		if grpcShouldEscape(msg[i]) {
 			hexCount++
 		}
@@ -434,7 +439,7 @@ func grpcPercentEncode(msg string) string {
 	// We need to escape some characters, so we'll need to allocate a new string.
 	var out strings.Builder
 	out.Grow(len(msg) + 2*hexCount)
-	for i := 0; i < len(msg); i++ {
+	for i := range len(msg) {
 		switch char := msg[i]; {
 		case grpcShouldEscape(char):
 			out.WriteByte('%')
@@ -508,16 +513,17 @@ func grpcExtractErrorFromTrailer(trailers http.Header) *connect.Error {
 		return nil
 	}
 
-	code, err := strconv.ParseUint(codeHeader, 10 /* base */, 32 /* bitsize */)
+	code64, err := strconv.ParseUint(codeHeader, 10 /* base */, 32 /* bitsize */)
 	if err != nil {
 		return connect.NewError(
 			connect.CodeInternal,
 			protocolError("invalid error code %q: %w", codeHeader, err),
 		)
 	}
-	if code == 0 {
+	if code64 == 0 {
 		return nil
 	}
+	code := uint32(code64)
 
 	if len(grpcDetails) == 0 {
 		message, err := grpcPercentDecode(grpcMsg)
@@ -545,7 +551,10 @@ func grpcExtractErrorFromTrailer(trailers http.Header) *connect.Error {
 			protocolError("invalid protobuf for error details: %w", err),
 		)
 	}
-	trailerErr := connect.NewWireError(connect.Code(stat.GetCode()), errors.New(stat.GetMessage()))
+	trailerErr := connect.NewWireError(
+		connect.Code(stat.GetCode()), //nolint:gosec // No information loss.
+		errors.New(stat.GetMessage()),
+	)
 	for _, msg := range stat.GetDetails() {
 		errDetail, err := connect.NewErrorDetail(msg)
 		if err != nil {

--- a/protocol_grpc_test.go
+++ b/protocol_grpc_test.go
@@ -100,7 +100,6 @@ func TestGRPCPercentEncoding(t *testing.T) {
 		`foo%bar`,
 		"fiancée",
 	} {
-		input := input
 		t.Run(input, func(t *testing.T) {
 			t.Parallel()
 			assert.True(t, utf8.ValidString(input), "input invalid UTF-8")

--- a/protocol_http.go
+++ b/protocol_http.go
@@ -119,12 +119,11 @@ func httpErrorFromResponse(statusCode int, contentType string, src *bytes.Buffer
 			return connect.NewError(connect.CodeInternal, err)
 		}
 		stat.Details = append(stat.Details, body)
-		stat.Code = int32(httpStatusCodeToRPC(statusCode))
+		stat.Code = int32(httpStatusCodeToRPC(statusCode)) //nolint:gosec
 		stat.Message = http.StatusText(statusCode)
 	}
-
 	connectErr := connect.NewWireError(
-		connect.Code(stat.GetCode()),
+		connect.Code(stat.GetCode()), //nolint:gosec // No information loss.
 		errors.New(stat.GetMessage()),
 	)
 	for _, msg := range stat.GetDetails() {

--- a/protocol_http_test.go
+++ b/protocol_http_test.go
@@ -48,7 +48,7 @@ func TestHTTPErrorWriter(t *testing.T) {
 	assert.Equal(t, "identity", rec.Header().Get("Content-Encoding"))
 	var out bytes.Buffer
 	require.NoError(t, json.Compact(&out, rec.Body.Bytes()))
-	assert.Equal(t, `{"code":16,"message":"test error: Hello, 世界","details":[]}`, out.String())
+	assert.JSONEq(t, `{"code":16,"message":"test error: Hello, 世界","details":[]}`, out.String())
 
 	body := bytes.NewBuffer(rec.Body.Bytes())
 	got := httpErrorFromResponse(http.StatusUnauthorized, "application/json", body)
@@ -242,7 +242,6 @@ func TestHTTPEncodePathValues(t *testing.T) {
 		wantErr:      "unknown field in field path \"unknownQueryParam\": element \"unknownQueryParam\" does not correspond to any field of type vanguard.test.v1.ParameterValues",
 	}}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.tmpl, func(t *testing.T) {
 			t.Parallel()
 			segments, variables, err := parsePathTemplate(testCase.tmpl)

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -59,7 +59,6 @@ func TestParseMultiHeader(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			result := parseMultiHeader(testCase.input)

--- a/regress_test.go
+++ b/regress_test.go
@@ -57,8 +57,10 @@ func TestIssue148(t *testing.T) {
 	proxy.FlushInterval = -1 // shouldn't be necessary
 	schema, err := protoregistry.GlobalFiles.FindDescriptorByName("connectrpc.eliza.v1.ElizaService")
 	require.NoError(t, err)
+	schemaService, ok := schema.(protoreflect.ServiceDescriptor)
+	require.True(t, ok)
 	transcoder, err := vanguard.NewTranscoder(
-		[]*vanguard.Service{vanguard.NewServiceWithSchema(schema.(protoreflect.ServiceDescriptor), proxy)},
+		[]*vanguard.Service{vanguard.NewServiceWithSchema(schemaService, proxy)},
 		vanguard.WithDefaultServiceOptions(
 			vanguard.WithTargetProtocols(vanguard.ProtocolGRPCWeb),
 			vanguard.WithTargetCodecs(vanguard.CodecProto),
@@ -81,7 +83,6 @@ func TestIssue148(t *testing.T) {
 		"json":  {connect.WithGRPC(), connect.WithProtoJSON()},
 	}
 	for caseName := range clientCases {
-		caseName := caseName
 		clientOpts := clientCases[caseName]
 		t.Run(caseName, func(t *testing.T) {
 			t.Parallel()

--- a/router_test.go
+++ b/router_test.go
@@ -146,7 +146,6 @@ func TestRouteTrie_FindTarget(t *testing.T) {
 	trie := initTrie(t)
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.path, func(t *testing.T) {
 			t.Parallel()
 			var present, absent []string
@@ -157,7 +156,6 @@ func TestRouteTrie_FindTarget(t *testing.T) {
 				absent = []string{http.MethodGet, http.MethodPost, http.MethodDelete, http.MethodPut}
 			}
 			for _, method := range present {
-				method := method
 				t.Run(method, func(t *testing.T) {
 					t.Parallel()
 					target, vars, _ := trie.match(testCase.path, method)
@@ -177,7 +175,6 @@ func TestRouteTrie_FindTarget(t *testing.T) {
 				})
 			}
 			for _, method := range absent {
-				method := method
 				t.Run(method, func(t *testing.T) {
 					t.Parallel()
 					target, _, _ := trie.match(testCase.path, method)
@@ -197,7 +194,7 @@ func BenchmarkTrieMatch(b *testing.B) {
 	)
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		method, vars, _ = trie.match(path, http.MethodPost)
 		if method == nil {
 			b.Fatal("method not found")

--- a/transcoder.go
+++ b/transcoder.go
@@ -875,16 +875,11 @@ func (r *envelopingReader) prepareNext() error {
 			// Oof. We have to buffer entire request in order to measure it.
 			limit := int64(r.rw.op.methodConf.maxMsgBufferBytes)
 			buf := r.rw.op.bufferPool.Get()
-			written, err := io.Copy(buf, &hardLimitReader{r: r.r, rw: r.rw, limit: limit + 1})
+			_, err := io.Copy(buf, &hardLimitReader{r: r.r, rw: r.rw, limit: limit + 1})
 			if err != nil {
 				r.rw.op.bufferPool.Put(buf)
 				r.err = err
 				return err
-			}
-			if written > limit {
-				r.rw.op.bufferPool.Put(buf)
-				r.err = bufferLimitError(limit)
-				return r.err
 			}
 			r.current = buf
 			r.mustReleaseCurrent = true

--- a/transcoder_bench_test.go
+++ b/transcoder_bench_test.go
@@ -54,7 +54,7 @@ func BenchmarkServeHTTP(b *testing.B) {
 	envelopePayload := func(flags uint8, msg []byte) []byte {
 		head := [5]byte{}
 		head[0] = flags
-		binary.BigEndian.PutUint32(head[1:5], uint32(len(msg)))
+		binary.BigEndian.PutUint32(head[1:5], uint32(len(msg))) //nolint:gosec // Safe for testing
 		body := &bytes.Buffer{}
 		body.Write(head[:])
 		body.Write(msg)
@@ -206,7 +206,7 @@ func BenchmarkServeHTTP(b *testing.B) {
 				data := rsp.Body.Bytes()
 				rsp.Body.Reset()
 				require.NoError(b, json.Compact(rsp.Body, data))
-				assert.Equal(b, rspMsgJSON, rsp.Body.Bytes(), "response body")
+				assert.JSONEq(b, string(rspMsgJSON), rsp.Body.String(), "response body")
 			}
 		})
 		b.StopTimer()
@@ -283,7 +283,7 @@ func BenchmarkServeHTTP(b *testing.B) {
 
 		b.StartTimer()
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			req := req.Clone(ctx)
 			req.Body = io.NopCloser(bytes.NewReader(reqMsgJSON))
 			rsp := httptest.NewRecorder()
@@ -294,7 +294,7 @@ func BenchmarkServeHTTP(b *testing.B) {
 			data := rsp.Body.Bytes()
 			rsp.Body.Reset()
 			require.NoError(b, json.Compact(rsp.Body, data))
-			assert.Equal(b, rspMsgJSON, rsp.Body.Bytes(), "response body")
+			assert.JSONEq(b, string(rspMsgJSON), rsp.Body.String(), "response body")
 		}
 		b.StopTimer()
 	})

--- a/vanguard_restxrpc_test.go
+++ b/vanguard_restxrpc_test.go
@@ -596,11 +596,9 @@ func TestMux_RESTxRPC(t *testing.T) {
 	}
 	codec := NewJSONCodec(protoregistry.GlobalTypes)
 	for _, opts := range testOpts {
-		opts := opts
 		t.Run(opts.name, func(t *testing.T) {
 			t.Parallel()
 			for _, testCase := range testRequests {
-				testCase := testCase
 				t.Run(testCase.name, func(t *testing.T) {
 					t.Parallel()
 

--- a/vanguard_rpcxrest_test.go
+++ b/vanguard_rpcxrest_test.go
@@ -420,7 +420,6 @@ func TestMux_RPCxREST(t *testing.T) {
 	}}
 
 	for _, opts := range testOpts {
-		opts := opts
 		clients := testClients{
 			libClient: testv1connect.NewLibraryServiceClient(
 				opts.server.Client(), opts.server.URL, opts.opts...,
@@ -432,7 +431,6 @@ func TestMux_RPCxREST(t *testing.T) {
 		t.Run(opts.name, func(t *testing.T) {
 			t.Parallel()
 			for _, req := range testRequests {
-				req := req
 				t.Run(req.name, func(t *testing.T) {
 					t.Parallel()
 

--- a/vanguard_rpcxrpc_test.go
+++ b/vanguard_rpcxrpc_test.go
@@ -395,7 +395,6 @@ func TestMux_RPCxRPC(t *testing.T) {
 		},
 	}
 	for _, opts := range testOpts {
-		opts := opts
 		clients := testClients{
 			libClient: testv1connect.NewLibraryServiceClient(
 				opts.server.Client(), opts.server.URL, opts.opts...,
@@ -406,8 +405,7 @@ func TestMux_RPCxRPC(t *testing.T) {
 		}
 		t.Run(opts.name, func(t *testing.T) {
 			t.Parallel()
-			for _, testReq := range testRequests {
-				testCase := testReq
+			for _, testCase := range testRequests {
 				t.Run(testCase.name, func(t *testing.T) {
 					t.Parallel()
 					runRPCTestCase(t, &interceptor, clients, testCase.invoke, testCase.stream)

--- a/vanguard_test.go
+++ b/vanguard_test.go
@@ -784,8 +784,11 @@ func outputFromUnary[Req, Resp any](
 	if len(reqs) != 1 {
 		return nil, nil, nil, fmt.Errorf("unary method takes exactly 1 request but got %d", len(reqs))
 	}
-	req := any(reqs[0])
-	resp, err := method(ctx, makeRequest(headers, req.(*Req)))
+	req, ok := any(reqs[0]).(*Req)
+	if !ok {
+		return nil, nil, nil, fmt.Errorf("expected *%T, got %T", new(Req), reqs[0])
+	}
+	resp, err := method(ctx, makeRequest(headers, req))
 	if err != nil {
 		var headers http.Header
 		if connErr := new(connect.Error); errors.As(err, &connErr) {
@@ -793,8 +796,11 @@ func outputFromUnary[Req, Resp any](
 		}
 		return headers, nil, nil, err
 	}
-	msg := any(resp.Msg)
-	return resp.Header(), []proto.Message{msg.(proto.Message)}, resp.Trailer(), nil
+	msg, ok := any(resp.Msg).(proto.Message)
+	if !ok {
+		return nil, nil, nil, fmt.Errorf("expected proto.Message, got %T", resp.Msg)
+	}
+	return resp.Header(), []proto.Message{msg}, resp.Trailer(), nil
 }
 
 func outputFromServerStream[Req, Resp any](
@@ -808,8 +814,11 @@ func outputFromServerStream[Req, Resp any](
 	if len(reqs) != 1 {
 		return nil, nil, nil, fmt.Errorf("unary method takes exactly 1 request but got %d", len(reqs))
 	}
-	req := any(reqs[0])
-	str, err := method(ctx, makeRequest(headers, req.(*Req)))
+	req, ok := any(reqs[0]).(*Req)
+	if !ok {
+		return nil, nil, nil, fmt.Errorf("expected *%T, got %T", new(Req), reqs[0])
+	}
+	str, err := method(ctx, makeRequest(headers, req))
 	if err != nil {
 		var headers http.Header
 		if connErr := new(connect.Error); errors.As(err, &connErr) {
@@ -819,8 +828,11 @@ func outputFromServerStream[Req, Resp any](
 	}
 	var msgs []proto.Message
 	for str.Receive() {
-		msg := any(str.Msg())
-		msgs = append(msgs, msg.(proto.Message))
+		msg, ok := any(str.Msg()).(proto.Message)
+		if !ok {
+			return nil, nil, nil, fmt.Errorf("expected proto.Message, got %T", str.Msg())
+		}
+		msgs = append(msgs, msg)
 	}
 	return str.ResponseHeader(), msgs, str.ResponseTrailer(), str.Err()
 }
@@ -838,7 +850,11 @@ func outputFromClientStream[Req, Resp any](
 		str.RequestHeader()[k] = v
 	}
 	for _, msg := range reqs {
-		if str.Send(any(msg).(*Req)) != nil {
+		req, ok := any(msg).(*Req)
+		if !ok {
+			return nil, nil, nil, fmt.Errorf("expected *%T, got %T", new(Req), msg)
+		}
+		if str.Send(req) != nil {
 			// we don't need this error; we'll get the error below
 			// since str.CloseAndReceive returns the actual RPC errors
 			break
@@ -852,8 +868,11 @@ func outputFromClientStream[Req, Resp any](
 		}
 		return headers, nil, nil, err
 	}
-	msg := any(resp.Msg)
-	return resp.Header(), []proto.Message{msg.(proto.Message)}, resp.Trailer(), nil
+	msg, ok := any(resp.Msg).(proto.Message)
+	if !ok {
+		return nil, nil, nil, fmt.Errorf("expected proto.Message, got %T", resp.Msg)
+	}
+	return resp.Header(), []proto.Message{msg}, resp.Trailer(), nil
 }
 
 func outputFromBidiStream[Req, Resp any](
@@ -882,8 +901,12 @@ func outputFromBidiStream[Req, Resp any](
 				}
 				return
 			}
-			msg := any(resp)
-			msgs = append(msgs, msg.(proto.Message))
+			msg, ok := any(resp).(proto.Message)
+			if !ok {
+				err = fmt.Errorf("expected proto.Message, got %T", resp)
+				break
+			}
+			msgs = append(msgs, msg)
 		}
 	}()
 
@@ -891,7 +914,11 @@ func outputFromBidiStream[Req, Resp any](
 		str.RequestHeader()[k] = v
 	}
 	for _, msg := range reqs {
-		if str.Send(any(msg).(*Req)) != nil {
+		req, ok := any(msg).(*Req)
+		if !ok {
+			return nil, nil, nil, fmt.Errorf("expected *%T, got %T", new(Req), msg)
+		}
+		if str.Send(req) != nil {
 			// we don't need this error; we'll get the error from above
 			// goroutine since str.Receive returns the actual RPC errors
 			break


### PR DESCRIPTION
Upgrades the min go to v1.22 and tools buf and golangci-lint, fixing lint issues found.