### PR TITLE
Fix panic on WriteHeader with unset Content-Type

### DIFF
--- a/protocol_rest.go
+++ b/protocol_rest.go
@@ -437,6 +437,9 @@ func restHTTPBodyRequest(op *operation) bool {
 }
 
 func restHTTPBodyResponse(op *operation) bool {
+	if op.restTarget == nil {
+		return false
+	}
 	return restIsHTTPBody(op.methodConf.descriptor.Output(), op.restTarget.responseBodyFields)
 }
 

--- a/transcoder.go
+++ b/transcoder.go
@@ -1103,12 +1103,6 @@ func (w *responseWriter) WriteHeader(statusCode int) {
 		w.op.client.respCompression = respCompression
 		w.op.server.respCompression = respCompression
 	}
-	if respMeta.codec != "" && respMeta.codec != w.op.server.codec.Name() &&
-		!restHTTPBodyResponse(w.op) {
-		// unexpected content-type for reply
-		w.reportError(fmt.Errorf("response uses incorrect codec: expecting %q but instead got %q", w.op.server.codec.Name(), respMeta.codec))
-		return
-	}
 
 	if respMeta.end != nil {
 		// RPC failed immediately.
@@ -1125,6 +1119,13 @@ func (w *responseWriter) WriteHeader(statusCode int) {
 		// We can send back error response immediately.
 		w.flushHeaders()
 		w.w = noResponseBodyWriter{}
+		return
+	}
+
+	if respMeta.codec != "" && respMeta.codec != w.op.server.codec.Name() &&
+		!restHTTPBodyResponse(w.op) {
+		// unexpected content-type for reply
+		w.reportError(fmt.Errorf("response uses incorrect codec: expecting %q but instead got %q", w.op.server.codec.Name(), respMeta.codec))
 		return
 	}
 


### PR DESCRIPTION
I have a use-case where I am proxying through Vanguard for protocol translation. Mostly Connect to genuine Grpc endpoints.

Currently vanguard panics when the proxy returns an error without a properly-set Content-Type while no proto httpRules exist.

```
net/http.(*conn).serve.func1()
 /usr/lib/go/src/net/http/server.go:1947 +0xbe
panic({0xcbe100?, 0x1e57080?})
 /usr/lib/go/src/runtime/panic.go:792 +0x132
connectrpc.com/vanguard.restHTTPBodyResponse(0xc00025a200)
 ~/vanguard-go/protocol_rest.go:453 +0x40
connectrpc.com/vanguard.(*responseWriter).WriteHeader(0xc0003e8300, 0x1f6)
 ~/vanguard-go/transcoder.go:1107 +0x614
net/http/httputil.(*ReverseProxy).defaultErrorHandler(0xc0002be1e0?, {0x1852268, 0xc0003e8300}, 0x184ada0?, {0x184a200?, 0xc0000dc8c0?})
 /usr/lib/go/src/net/http/httputil/reverseproxy.go:308 +0x6e
net/http/httputil.(*ReverseProxy).ServeHTTP(0xc0002b0be0, {0x1852268, 0xc0003e8300}, 0xc00048ac80)
 /usr/lib/go/src/net/http/httputil/reverseproxy.go:486 +0x101f
connectrpc.com/vanguard.(*operation).handle(0xc00025a200)
 ~/vanguard-go/transcoder.go:605 +0xa7a
connectrpc.com/vanguard.(*Transcoder).ServeHTTP(0xc000296b40, {0x1851758, 0xc0001b8460}, 0xc00048ab40)
 ~/vanguard-go/transcoder.go:85 +0x227
net/http.(*ServeMux).ServeHTTP(0xc00063fb18?, {0x1851758, 0xc0001b8460}, 0xc00048aa00)
 /usr/lib/go/src/net/http/server.go:2822 +0x1c4
net/http.HandlerFunc.ServeHTTP(0x470fd9?, {0x1851758?, 0xc0001b8460?}, 0xc00063fb70?)
 /usr/lib/go/src/net/http/server.go:2294 +0x29
net/http.serverHandler.ServeHTTP({0xc0000a4630?}, {0x1851758?, 0xc0001b8460?}, 0x6?)
 /usr/lib/go/src/net/http/server.go:3301 +0x8e
net/http.(*conn).serve(0xc00026a2d0, {0x1852a78, 0xc00026e120})
 /usr/lib/go/src/net/http/server.go:2102 +0x625
created by net/http.(*Server).Serve in goroutine 10
 /usr/lib/go/src/net/http/server.go:3454 +0x485
http: panic serving 192.168.42.231:47648: runtime error: invalid memory address or nil pointer dereference
```

Prevent this by:
- evaluating end error before checking ContentType
- preventing restHTTPBodyResponse panic when restTarget is nil

Feel free to integrate the test case somewhere else.
The test case doesn't actually panic, because the Library proto has httpRules set. Maybe it would be worthwile to add a proto without httpRules for testing those cases.