### PR TITLE
Fix build failure on arm32

### DIFF
--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -186,10 +186,11 @@ func (g grpcWebClientProtocol) encodeEnd(op *operation, end *responseEnd, writer
 	defer op.bufferPool.Put(buffer)
 	_ = trailers.Write(buffer)
 	// TODO: Send envelope compressed if possible.
-	length := len(buffer.Bytes())
+	length := int64(len(buffer.Bytes()))
 	if length > math.MaxUint32 {
 		return nil
 	}
+	//nolint:gosec // gosec gives a false positive for int64
 	env := envelope{trailer: true, length: uint32(length)}
 	envBytes := g.encodeEnvelope(env)
 	_, _ = writer.Write(envBytes[:])


### PR DESCRIPTION
Currently building for GOARCH=arm is broken. 

```
$ GOARCH=arm make
make test
.tmp/bin/buf generate internal/proto
cd internal/examples/pets && ../../../.tmp/bin/buf generate internal/proto
comm -23 \
        <(git ls-files --cached --modified --others --no-empty-directory --exclude-standard | sort -u | grep -v -e testdata/ ) \
        <(git ls-files --deleted | sort -u) | \
        xargs .tmp/bin/license-header \
                --license-type apache \
                --copyright-holder "Buf Technologies, Inc." \
                --year-range "2023-2025"
go build ./...
# connectrpc.com/vanguard
./protocol_grpc.go:190:14: math.MaxUint32 (untyped int constant 4294967295) overflows int
make[1]: *** [Makefile:38: build] Error 1
make: *** [Makefile:22: all] Error 2

```

I know you probably don't want to officially support it, but vanguard-1.0 we have been using so far built and ran fine on arm.

Unfortunately gosec doesn't correctly detect the overflow check if we cast len to int64 so we need to explicitely disable it.