### PR TITLE
Use mime.ParseMediaType for REST Content-Type validation

### DIFF
--- a/protocol_rest.go
+++ b/protocol_rest.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"strconv"
 	"strings"
@@ -79,12 +80,12 @@ func (r restClientProtocol) extractProtocolRequestHeaders(op *operation, headers
 
 	reqMeta.codec = CodecJSON // if actually a custom content-type, handled by body preparer methods
 	contentType := headers.Get("Content-Type")
-	if contentType != "" &&
-		contentType != "application/json" &&
-		contentType != "application/json; charset=utf-8" &&
-		!restHTTPBodyRequest(op) {
-		// invalid content-type
-		reqMeta.codec = contentType + "?"
+	if contentType != "" && !restHTTPBodyRequest(op) {
+		mediaType, _, _ := mime.ParseMediaType(contentType)
+		if mediaType != "application/json" {
+			// invalid content-type
+			reqMeta.codec = contentType + "?"
+		}
 	}
 	headers.Del("Content-Type")
 

--- a/protocol_rest.go
+++ b/protocol_rest.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"mime"
 	"net/http"
 	"strconv"
 	"strings"
@@ -81,7 +80,8 @@ func (r restClientProtocol) extractProtocolRequestHeaders(op *operation, headers
 	reqMeta.codec = CodecJSON // if actually a custom content-type, handled by body preparer methods
 	contentType := headers.Get("Content-Type")
 	if contentType != "" && !restHTTPBodyRequest(op) {
-		mediaType, _, _ := mime.ParseMediaType(contentType)
+		base, _, _ := strings.Cut(contentType, ";")
+		mediaType := strings.TrimSpace(strings.ToLower(base))
 		if mediaType != "application/json" {
 			// invalid content-type
 			reqMeta.codec = contentType + "?"

--- a/transcoder_test.go
+++ b/transcoder_test.go
@@ -821,6 +821,37 @@ func TestTranscoder_Errors(t *testing.T) {
 			},
 			expectedCode: http.StatusUnsupportedMediaType,
 		},
+		// The following three cases verify that charset variants of application/json
+		// are NOT rejected as unsupported media types (415). The requests reach the
+		// handler (which returns a non-protobuf response causing a 500), proving that
+		// the content type check accepts these valid charset variations.
+		{
+			name:          "rest, json with uppercase charset",
+			requestURL:    "/v1/shelves/reference-123/books/isbn-0000111230012",
+			requestMethod: "GET",
+			requestHeaders: map[string][]string{
+				"Content-Type": {"application/json; charset=UTF-8"},
+			},
+			expectedCode: http.StatusInternalServerError,
+		},
+		{
+			name:          "rest, json with no space before charset",
+			requestURL:    "/v1/shelves/reference-123/books/isbn-0000111230012",
+			requestMethod: "GET",
+			requestHeaders: map[string][]string{
+				"Content-Type": {"application/json;charset=utf-8"},
+			},
+			expectedCode: http.StatusInternalServerError,
+		},
+		{
+			name:          "rest, json with mixed case charset",
+			requestURL:    "/v1/shelves/reference-123/books/isbn-0000111230012",
+			requestMethod: "GET",
+			requestHeaders: map[string][]string{
+				"Content-Type": {"application/json; charset=Utf-8"},
+			},
+			expectedCode: http.StatusInternalServerError,
+		},
 		{
 			name:          "connect stream, unknown codec",
 			requestURL:    "/vanguard.test.v1.ContentService/Download",


### PR DESCRIPTION
## Summary

Fixes #188.

`extractProtocolRequestHeaders` uses exact string comparison for `Content-Type`, only accepting `"application/json"` and `"application/json; charset=utf-8"`. This rejects valid variations like:

- `application/json; charset=UTF-8` (uppercase — common in Java HTTP clients)
- `application/json;charset=utf-8` (no space after semicolon)
- `application/json; charset=Utf-8` (mixed case)

All of these are valid per RFC 9110 §8.3.2 (charset values are case-insensitive) and RFC 7231 (optional whitespace around the semicolon).

The fix replaces the hardcoded comparisons with `mime.ParseMediaType`, which correctly handles all of these variations. This aligns with the response side (`extractProtocolResponseHeaders`), which already strips charset params.

## Changes

- **`protocol_rest.go`**: Replace exact string matching with `mime.ParseMediaType` to extract the media type for comparison
- **`transcoder_test.go`**: Add test cases for uppercase, no-space, and mixed-case charset variants