### PR TITLE
Fix multi-segment bounded path variables with %2F

### DIFF
--- a/router.go
+++ b/router.go
@@ -315,7 +315,7 @@ func (v routeTargetVar) index(segments []string) []string {
 func (v routeTargetVar) capture(segments []string) (string, error) {
 	parts := v.index(segments)
 	mode := pathEncodeSingle
-	if v.end == -1 || v.start-v.end > 1 {
+	if v.end == -1 || len(parts) > 1 {
 		mode = pathEncodeMulti
 	}
 	var sb strings.Builder

--- a/router_test.go
+++ b/router_test.go
@@ -142,21 +142,21 @@ func TestRouteTrie_FindTarget(t *testing.T) {
 			expectedVars: map[string]string{"thing.id": "/", "cat": "*/%2F"},
 		},
 		{
-			// Var capture on multi-segment variable with end != -1 preserves %2F
-			path:         "/foo/blah/A%2fb/B/C/foo/D/E/F/G/foo/H/I/J/K/L/M:details",
-			expectedPath: "/foo/blah/{longest_var={long_var.a={medium.a={short.aa}/*/{short.ab}/foo}/*}/{long_var.b={medium.b={short.ba}/*/{short.bb}/foo}/{last=**}}}:details",
+			// A single-segment var decodes %2F to a literal slash.
+			// The multi-segment var enclosing it preserves %2F percent-encoded.
+			path:         "/percent_encoding/A%2Fb/suffix",
+			expectedPath: "/percent_encoding/{outer={inner}/suffix}",
 			expectedVars: map[string]string{
-				"longest_var": "A%2Fb/B/C/foo/D/E/F/G/foo/H/I/J/K/L/M",
-				"long_var.a":  "A%2Fb/B/C/foo/D",
-				"medium.a":    "A%2Fb/B/C/foo",
-				"short.aa":    "A/b", // Single segment variable unescapes %2F to /
-				"short.ab":    "C",
-				"long_var.b":  "E/F/G/foo/H/I/J/K/L/M",
-				"medium.b":    "E/F/G/foo",
-				"short.ba":    "E",
-				"short.bb":    "G",
-				"last":        "H/I/J/K/L/M",
+				"inner": "A/b",      // single-segment: %2F decoded
+				"outer": "A%2Fb/suffix", // bounded multi-segment: %2F preserved
 			},
+		},
+		{
+			// A tail-spanning var ({cat=**}) also preserves %2F percent-encoded,
+			// consistent with all multi-segment vars.
+			path:         "/foo/bar/baz/123/a%2Fb",
+			expectedPath: "/foo/bar/*/{thing.id}/{cat=**}",
+			expectedVars: map[string]string{"thing.id": "123", "cat": "a%2Fb"},
 		},
 	}
 
@@ -231,6 +231,7 @@ func initTrie(tb testing.TB) *routeTrie {
 		"/foo/bar/{name}/baz/{child}",
 		"/foo/bar/{name}/baz/{child.id}/buzz/{child.thing.id}",
 		"/foo/bar/*/{thing.id}/{cat=**}",
+		"/percent_encoding/{outer={inner}/suffix}",
 		"/foo/bar/*/{thing.id}/{cat=**}:do",
 		"/foo/bar/*/{thing.id}/{cat=**}:cancel",
 		"/foo/bob/{book_id={author}/{isbn}/*}/details",

--- a/router_test.go
+++ b/router_test.go
@@ -141,6 +141,23 @@ func TestRouteTrie_FindTarget(t *testing.T) {
 			expectedPath: "/foo/bar/*/{thing.id}/{cat=**}",
 			expectedVars: map[string]string{"thing.id": "/", "cat": "*/%2F"},
 		},
+		{
+			// Var capture on multi-segment variable with end != -1 preserves %2F
+			path:         "/foo/blah/A%2fb/B/C/foo/D/E/F/G/foo/H/I/J/K/L/M:details",
+			expectedPath: "/foo/blah/{longest_var={long_var.a={medium.a={short.aa}/*/{short.ab}/foo}/*}/{long_var.b={medium.b={short.ba}/*/{short.bb}/foo}/{last=**}}}:details",
+			expectedVars: map[string]string{
+				"longest_var": "A%2Fb/B/C/foo/D/E/F/G/foo/H/I/J/K/L/M",
+				"long_var.a":  "A%2Fb/B/C/foo/D",
+				"medium.a":    "A%2Fb/B/C/foo",
+				"short.aa":    "A/b", // Single segment variable unescapes %2F to /
+				"short.ab":    "C",
+				"long_var.b":  "E/F/G/foo/H/I/J/K/L/M",
+				"medium.b":    "E/F/G/foo",
+				"short.ba":    "E",
+				"short.bb":    "G",
+				"last":        "H/I/J/K/L/M",
+			},
+		},
 	}
 
 	trie := initTrie(t)

--- a/router_test.go
+++ b/router_test.go
@@ -147,7 +147,7 @@ func TestRouteTrie_FindTarget(t *testing.T) {
 			path:         "/percent_encoding/A%2Fb/suffix",
 			expectedPath: "/percent_encoding/{outer={inner}/suffix}",
 			expectedVars: map[string]string{
-				"inner": "A/b",      // single-segment: %2F decoded
+				"inner": "A/b",          // single-segment: %2F decoded
 				"outer": "A%2Fb/suffix", // bounded multi-segment: %2F preserved
 			},
 		},


### PR DESCRIPTION
This PR fixes a routing bug where URL path variables containing encoded slashes (`%2F` or `%2f`) were incorrectly decoded to raw slashes (`/`), leading to corrupted variable values and broken routing.

When a URL route contains a multi-segment variable (such as matching a subpath or wildcard range like `foo/{path=*}`), and the user requests a path containing an encoded slash (e.g., `/foo/some%2Fvalue`), Vanguard is supposed to preserve `%2F` to keep the segment intact.

Instead, due to a bug in determining if a variable covers multiple segments:
* Bounded multi-segment variables were incorrectly treated as single-segment variables.
* This caused `%2F` to be aggressively decoded to a literal `/`.
* **Effect:** The captured variable value became `some/value` instead of `some%2Fvalue`. This corrupted the routing data and broke downstream REST API path mappings.

## Corrected Behavior
With this fix:
* Multi-segment variables are correctly identified.
* Encoded slashes (`%2F` / `%2f`) captured within these variable segments are correctly preserved as `%2F`.
* The captured variable values match the expected format (e.g. `some%2Fvalue`).
